### PR TITLE
fix assume role arns

### DIFF
--- a/aws-integration-setup/cloudformation/nullify-cloudformation-template.json
+++ b/aws-integration-setup/cloudformation/nullify-cloudformation-template.json
@@ -193,9 +193,7 @@
                     },
                     "Effect": "Allow",
                     "Principal": {
-                      "AWS": {
-                        "Ref": "CrossAccountRoleArn"
-                      }
+                      "AWS": {"Fn::Sub": "${CrossAccountRoleArn}"}
                     }
                   },
                   {
@@ -228,9 +226,7 @@
                     },
                     "Effect": "Allow",
                     "Principal": {
-                      "AWS": {
-                        "Ref": "CrossAccountRoleArn"
-                      }
+                      "AWS": {"Fn::Sub": "${CrossAccountRoleArn}"}
                     }
                   }
                 ],

--- a/aws-integration-setup/terraform/examples/multi-cluster-complete/main.tf
+++ b/aws-integration-setup/terraform/examples/multi-cluster-complete/main.tf
@@ -34,37 +34,37 @@ data "aws_eks_cluster_auth" "secondary" {
 }
 
 provider "kubernetes" {
-  alias = "primary"
+  alias                  = "primary"
   host                   = data.aws_eks_cluster.primary.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.primary.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.primary.token
 }
 
 provider "kubernetes" {
-  alias = "secondary"
+  alias                  = "secondary"
   host                   = data.aws_eks_cluster.secondary.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.secondary.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.secondary.token
 }
 
 module "nullify_aws_integration" {
-  source = "../../modules/nullify-aws-integration"
+  source           = "../../modules/nullify-aws-integration"
   customer_name    = var.customer_name
   external_id      = var.external_id
   nullify_role_arn = var.nullify_role_arn
-  aws_region     = var.aws_region
-  s3_bucket_name = var.s3_bucket_name
-  kms_key_arn    = var.kms_key_arn
+  aws_region       = var.aws_region
+  s3_bucket_name   = var.s3_bucket_name
+  kms_key_arn      = var.kms_key_arn
 
   # Multiple Kubernetes Clusters Configuration
   enable_kubernetes_integration = true
   eks_cluster_arns              = var.eks_cluster_arns
   kubernetes_namespace          = var.kubernetes_namespace
-  tags = var.tags
+  tags                          = var.tags
 }
 
 module "k8s_resources_primary" {
-  source = "../../modules/k8s-resources"  
+  source = "../../modules/k8s-resources"
   providers = {
     kubernetes = kubernetes.primary
   }
@@ -78,7 +78,7 @@ module "k8s_resources_primary" {
 }
 
 module "k8s_resources_secondary" {
-  source = "../../modules/k8s-resources"  
+  source = "../../modules/k8s-resources"
   providers = {
     kubernetes = kubernetes.secondary
   }

--- a/aws-integration-setup/terraform/examples/multi-cluster-complete/outputs.tf
+++ b/aws-integration-setup/terraform/examples/multi-cluster-complete/outputs.tf
@@ -18,10 +18,10 @@ output "cluster_integration_summary" {
 output "k8s_resources" {
   description = "Kubernetes resources deployed to primary cluster"
   value = {
-    namespace_name           = module.k8s_resources.namespace_name
-    service_account_name     = module.k8s_resources.service_account_name
-    cluster_role_name        = module.k8s_resources.cluster_role_name
+    namespace_name            = module.k8s_resources.namespace_name
+    service_account_name      = module.k8s_resources.service_account_name
+    cluster_role_name         = module.k8s_resources.cluster_role_name
     cluster_role_binding_name = module.k8s_resources.cluster_role_binding_name
-    cronjob_name            = module.k8s_resources.cronjob_name
+    cronjob_name              = module.k8s_resources.cronjob_name
   }
 }

--- a/aws-integration-setup/terraform/modules/k8s-resources/main.tf
+++ b/aws-integration-setup/terraform/modules/k8s-resources/main.tf
@@ -39,7 +39,7 @@ resource "kubernetes_cluster_role" "nullify_readonly_role" {
     api_groups = [""]
     resources = [
       "pods",
-      "services", 
+      "services",
       "endpoints",
       "namespaces",
       "nodes",
@@ -186,7 +186,7 @@ resource "kubernetes_cron_job_v1" "k8s_collector" {
               }
 
               env {
-                name = "AWS_REGION"
+                name  = "AWS_REGION"
                 value = var.aws_region
               }
 

--- a/aws-integration-setup/terraform/modules/nullify-aws-integration/data.tf
+++ b/aws-integration-setup/terraform/modules/nullify-aws-integration/data.tf
@@ -9,7 +9,7 @@ locals {
   all_clusters_info = var.enable_kubernetes_integration ? [
     for i, cluster in data.aws_eks_cluster.clusters : {
       oidc_id = split("/", cluster.identity[0].oidc[0].issuer)[4]
-      region  = split(":", var.eks_cluster_arns[i])[3]  # Extract region from ARN
+      region  = split(":", var.eks_cluster_arns[i])[3] # Extract region from ARN
     }
   ] : []
 
@@ -499,7 +499,7 @@ data "aws_iam_policy_document" "readonly_policy_part2" {
 
 data "aws_iam_policy_document" "s3_access_policy" {
   count = local.enable_s3_access ? 1 : 0
-  
+
   statement {
     effect = "Allow"
     actions = [
@@ -516,7 +516,7 @@ data "aws_iam_policy_document" "s3_access_policy" {
 
 data "aws_iam_policy_document" "kms_access_policy" {
   count = local.enable_kms_access ? 1 : 0
-  
+
   statement {
     effect = "Allow"
     actions = [
@@ -582,4 +582,4 @@ data "aws_iam_policy_document" "deny_actions_policy" {
     ]
     resources = ["*"]
   }
-} 
+}

--- a/aws-integration-setup/terraform/modules/nullify-aws-integration/locals.tf
+++ b/aws-integration-setup/terraform/modules/nullify-aws-integration/locals.tf
@@ -2,27 +2,27 @@ locals {
   # Common naming
   role_name_prefix = "AWSIntegration-${var.customer_name}"
   role_name        = "${local.role_name_prefix}-NullifyReadOnlyRole"
-  
+
   # Policy names
   readonly_policy_part1_name = "${local.role_name_prefix}-ReadOnlyAccess-Part1"
   readonly_policy_part2_name = "${local.role_name_prefix}-ReadOnlyAccess-Part2"
   s3_access_policy_name      = "${local.role_name_prefix}-S3Access"
   kms_access_policy_name     = "${local.role_name_prefix}-KMSAccess"
   deny_actions_policy_name   = "${local.role_name_prefix}-DenyActions"
-  
+
   # Cross-account role ARN (use directly)
   nullify_role_arn = var.nullify_role_arn
 
   # OIDC subject for service account
   oidc_subject = "system:serviceaccount:${var.kubernetes_namespace}:${var.service_account_name}"
-  
+
   # S3 configuration
   enable_s3_access = var.s3_bucket_name != ""
   s3_bucket_arn    = var.s3_bucket_name != "" ? "arn:aws:s3:::${var.s3_bucket_name}" : ""
-  
+
   # KMS configuration
   enable_kms_access = var.kms_key_arn != ""
-  
+
   # Common tags
   common_tags = merge(var.tags, {
     Customer = var.customer_name

--- a/aws-integration-setup/terraform/modules/nullify-aws-integration/main.tf
+++ b/aws-integration-setup/terraform/modules/nullify-aws-integration/main.tf
@@ -26,7 +26,7 @@ resource "aws_iam_policy" "readonly_policy_part2" {
 
 resource "aws_iam_policy" "s3_access_policy" {
   count = local.enable_s3_access ? 1 : 0
-  
+
   name        = local.s3_access_policy_name
   description = "S3 access policy for Nullify bucket"
   policy      = data.aws_iam_policy_document.s3_access_policy[0].json
@@ -35,7 +35,7 @@ resource "aws_iam_policy" "s3_access_policy" {
 
 resource "aws_iam_policy" "kms_access_policy" {
   count = local.enable_kms_access ? 1 : 0
-  
+
   name        = local.kms_access_policy_name
   description = "KMS access policy for Nullify key management operations"
   policy      = data.aws_iam_policy_document.kms_access_policy[0].json
@@ -62,14 +62,14 @@ resource "aws_iam_role_policy_attachment" "readonly_policy_part2" {
 
 resource "aws_iam_role_policy_attachment" "s3_access_policy" {
   count = local.enable_s3_access ? 1 : 0
-  
+
   role       = aws_iam_role.nullify_readonly_role.name
   policy_arn = aws_iam_policy.s3_access_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "kms_access_policy" {
   count = local.enable_kms_access ? 1 : 0
-  
+
   role       = aws_iam_role.nullify_readonly_role.name
   policy_arn = aws_iam_policy.kms_access_policy[0].arn
 }

--- a/aws-integration-setup/terraform/modules/nullify-aws-integration/outputs.tf
+++ b/aws-integration-setup/terraform/modules/nullify-aws-integration/outputs.tf
@@ -78,12 +78,12 @@ output "policy_arns" {
 output "deployment_summary" {
   description = "Summary of the Nullify integration deployment"
   value = {
-    role_arn                   = aws_iam_role.nullify_readonly_role.arn
-    customer_name              = var.customer_name
-    aws_region                 = var.aws_region
-    s3_bucket                  = var.s3_bucket_name != "" ? var.s3_bucket_name : null
-    s3_integration_enabled     = local.enable_s3_access
-    kubernetes_integration     = var.enable_kubernetes_integration
-    total_clusters_configured  = var.enable_kubernetes_integration ? length(local.all_oidc_ids) : 0
+    role_arn                  = aws_iam_role.nullify_readonly_role.arn
+    customer_name             = var.customer_name
+    aws_region                = var.aws_region
+    s3_bucket                 = var.s3_bucket_name != "" ? var.s3_bucket_name : null
+    s3_integration_enabled    = local.enable_s3_access
+    kubernetes_integration    = var.enable_kubernetes_integration
+    total_clusters_configured = var.enable_kubernetes_integration ? length(local.all_oidc_ids) : 0
   }
 } 

--- a/aws-integration-setup/terraform/modules/nullify-aws-integration/variables.tf
+++ b/aws-integration-setup/terraform/modules/nullify-aws-integration/variables.tf
@@ -1,7 +1,7 @@
 variable "customer_name" {
   type        = string
   description = "The name of the customer to create the role for"
-  
+
   validation {
     condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_-]*$", var.customer_name))
     error_message = "Customer name must start with a letter and can only contain letters, numbers, underscores, and hyphens"
@@ -16,6 +16,11 @@ variable "external_id" {
 variable "nullify_role_arn" {
   type        = string
   description = "The Nullify cross-account role ARN"
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.nullify_role_arn))
+    error_message = "Must be a valid ARN for an IAM role in the format arn:aws:iam::<account-id>:role/<role-name>"
+  }
 }
 
 variable "enable_kubernetes_integration" {

--- a/aws-integration-setup/terraform/variables.tf
+++ b/aws-integration-setup/terraform/variables.tf
@@ -16,6 +16,11 @@ variable "external_id" {
 variable "nullify_role_arn" {
   type        = string
   description = "The Nullify cross-account role ARN"
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.nullify_role_arn))
+    error_message = "Must be a valid ARN for an IAM role in the format arn:aws:iam::<account-id>:role/<role-name>"
+  }
 }
 
 variable "enable_kubernetes_integration" {


### PR DESCRIPTION
## Description

Fixed: Changed the Principal AWS reference from {"Ref": "CrossAccountRoleArn"} to {"Fn::Sub": "${CrossAccountRoleArn}"} in both trust policy statements

Why: This ensures CloudFormation properly substitutes the ARN as a string instead of potentially resolving to a Role ID
