### PR TITLE
feat(helm): dual-mode nullify-k8s-collector for EKS and GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository provides comprehensive infrastructure-as-code templates for inte
 2. **CloudFormation** (`aws-integration-setup/cloudformation/`) - For AWS-centric infrastructure
 3. **Terraform** (`aws-integration-setup/terraform/`) - For infrastructure-as-code workflows with modular architecture
 4. **GCP Terraform** (`gcp-integration-setup/terraform/`) - For Google Cloud read-only integration via Workload Identity Federation
+5. **GKE Collector Terraform** (`gcp-integration-setup/terraform/modules/nullify-gke-collector/`) - For deploying the k8s-collector on GKE clusters
 
 ## 🚀 **Quick Start**
 
@@ -40,6 +41,7 @@ This repository provides comprehensive infrastructure-as-code templates for inte
 | **🏗️ CloudFormation** | AWS-centric infrastructure, ClickOps teams | AWS CLI, appropriate IAM permissions |
 | **🔧 Terraform (AWS)** | Infrastructure-as-code, multi-cluster teams | Terraform, AWS provider configured |
 | **☁️ Terraform (GCP)** | GCP environments, Workload Identity Federation | Terraform, `gcloud` auth on the host project, org or folder admin access |
+| **☁️ Terraform (GKE collector)** | GKE clusters running the Nullify k8s-collector | Terraform, GKE with Workload Identity enabled |
 
 ### **GCP Quick Start**
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 This repository provides comprehensive infrastructure-as-code templates for integrating Nullify's security platform with your cloud environment. It includes multiple deployment options to suit different infrastructure preferences and requirements.
 
 ### **What's Included**
-- ⚙️ **Helm Charts** - Production-ready Kubernetes deployment with IRSA support
+- ⚙️ **Helm Charts** - Production-ready Kubernetes deployment for **EKS (IRSA)** and **GKE (Workload Identity)**
 - 🏗️ **CloudFormation Templates** - AWS infrastructure setup with IAM roles and policies
 - 🔧 **Terraform Modules** - Modular infrastructure-as-code for AWS and multi-cluster EKS integration
+- ☁️ **GCP Terraform** - Read-only GCP integration via Workload Identity Federation
 - 🤖 **GitHub Actions** - Automated chart publishing and validation
 - 📚 **Documentation** - Comprehensive setup and security guides
 - ❌ **NO real sensitive data, bucket names, or account IDs**
@@ -35,7 +36,7 @@ This repository provides comprehensive infrastructure-as-code templates for inte
 
 | Method | Best For | Prerequisites |
 |--------|----------|---------------|
-| **🎯 Helm Charts** | Kubernetes-native teams, GitOps workflows | EKS cluster, Helm 3.x, kubectl |
+| **🎯 Helm Charts** | Kubernetes-native teams, GitOps workflows | EKS or GKE cluster, Helm 3.x, kubectl |
 | **🏗️ CloudFormation** | AWS-centric infrastructure, ClickOps teams | AWS CLI, appropriate IAM permissions |
 | **🔧 Terraform (AWS)** | Infrastructure-as-code, multi-cluster teams | Terraform, AWS provider configured |
 | **☁️ Terraform (GCP)** | GCP environments, Workload Identity Federation | Terraform, `gcloud` auth on the host project, org or folder admin access |
@@ -59,7 +60,7 @@ See [`gcp-integration-setup/terraform/README.md`](gcp-integration-setup/terrafor
 
 1. **AWS Account** with appropriate permissions
 2. **Nullify Account** and dashboard access
-3. **EKS Cluster** (for Kubernetes deployments)
+3. **Kubernetes cluster** for Helm deployments — **EKS** (IRSA) or **GKE** (Workload Identity). See the [chart README](helm-charts/nullify-k8s-collector/README.md#supported-platforms) for per-platform onboarding steps.
 
 **Obtain Configuration Values from Nullify Configure Page:**
 
@@ -319,7 +320,7 @@ nullify-cloud-connector/
 
 | Component | Purpose | Use When |
 |-----------|---------|----------|
-| **🎯 Helm Charts** | Deploy K8s collector with IRSA | You have EKS and prefer K8s-native tools |
+| **🎯 Helm Charts** | Deploy K8s collector (EKS via IRSA, GKE via Workload Identity) | You have EKS or GKE and prefer K8s-native tools |
 | **🏗️ CloudFormation** | Set up AWS IAM roles and policies | You prefer AWS-native infrastructure |
 | **🔧 Terraform** | Modular infrastructure-as-code with multi-cluster support | You use Terraform for infrastructure |
 | **🤖 GitHub Actions** | Automated testing and publishing | You want CI/CD for chart updates |

--- a/gcp-integration-setup/terraform/modules/nullify-gke-collector/README.md
+++ b/gcp-integration-setup/terraform/modules/nullify-gke-collector/README.md
@@ -1,0 +1,69 @@
+# Nullify GKE Collector — Terraform Module
+
+Creates the GCP-side resources needed to deploy the [Nullify Kubernetes collector](../../../helm-charts/nullify-k8s-collector/) on a GKE cluster.
+
+## What this module creates
+
+| Resource | Purpose |
+|---|---|
+| `google_service_account` | OIDC identity anchor — the collector pod impersonates this SA via Workload Identity. **No GCP IAM roles are needed**; the SA only signs tokens that AWS STS validates. |
+| `google_service_account_iam_member` | Workload Identity binding (`roles/iam.workloadIdentityUser`) that lets the in-cluster Kubernetes ServiceAccount impersonate the GCP SA. |
+
+## Prerequisites
+
+- **GKE Workload Identity** must be enabled on the cluster (`--workload-pool=PROJECT.svc.id.goog`). This module does not enable it — it's a cluster-level setting.
+- **Terraform** >= 1.3 with the `google` provider >= 4.0.
+
+## Usage
+
+```hcl
+module "nullify_gke_collector" {
+  source     = "./modules/nullify-gke-collector"
+  project_id = "my-gcp-project"
+}
+```
+
+After `terraform apply`:
+
+1. Share the `service_account_unique_id` output with Nullify. Nullify adds it to the federated IAM role's trust-policy allowlist and returns the AWS role ARN.
+2. Deploy the Helm chart:
+
+```yaml
+# values-gke.yaml
+cloudProvider: gcp
+
+collector:
+  clusterName: "my-gke-cluster"
+  aws:
+    region: "us-east-1"           # Region of the Nullify S3 bucket
+  s3:
+    bucket: "your-nullify-bucket" # Provided by Nullify
+  kms:
+    keyArn: "arn:aws:kms:..."     # Provided by Nullify
+  gke:
+    nullifyAwsRoleArn: "arn:aws:iam::123456789012:role/..." # Provided by Nullify
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: "<service_account_email output>"
+```
+
+```bash
+helm install nullify-k8s-collector ./nullify-k8s-collector -f values-gke.yaml
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project_id` | GCP project where the GKE cluster runs | `string` | — | yes |
+| `service_account_name` | Name of the GCP SA to create | `string` | `nullify-k8s-collector` | no |
+| `k8s_namespace` | Kubernetes namespace (must match Helm `serviceAccount.namespace`) | `string` | `nullify` | no |
+| `k8s_service_account_name` | Kubernetes SA name (must match Helm `serviceAccount.name`) | `string` | `nullify-k8s-collector-sa` | no |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `service_account_email` | GCP SA email — use as the `iam.gke.io/gcp-service-account` annotation in Helm values |
+| `service_account_unique_id` | 21-digit SA unique ID — share with Nullify for the AWS trust-policy allowlist |

--- a/gcp-integration-setup/terraform/modules/nullify-gke-collector/main.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gke-collector/main.tf
@@ -1,0 +1,65 @@
+# Nullify GKE Collector — customer-side GCP resources
+#
+# This module creates the minimal GCP resources a customer needs so the
+# Nullify k8s-collector running inside a GKE cluster can authenticate to
+# Nullify's AWS backend via Workload Identity Federation.
+#
+# The authentication flow:
+#
+#   1. GKE Workload Identity projects a Google-signed ServiceAccount ID
+#      token into the collector pod (audience: sts.amazonaws.com).
+#   2. The collector calls AWS sts:AssumeRoleWithWebIdentity, presenting
+#      that Google-signed token plus the Nullify-owned federated IAM role ARN.
+#   3. AWS validates the token against the accounts.google.com OIDC provider
+#      and checks that the token's `sub` claim (the GCP SA unique ID) is in
+#      the federated role's trust-policy allowlist.
+#   4. AWS returns short-lived credentials scoped to s3:PutObject on the
+#      k8s-collector/ prefix — the collector uploads cluster metadata and
+#      exits.
+#
+# No long-lived AWS credential is ever stored in the customer cluster, and
+# the GCP service account this module creates does NOT need any GCP IAM
+# roles — it is purely an OIDC identity anchor whose signed token AWS STS
+# trusts.
+#
+# Prerequisites:
+#   - GKE Workload Identity must be enabled on the cluster
+#     (--workload-pool=PROJECT.svc.id.goog). This module does NOT enable
+#     it; it is a cluster-level setting the customer manages.
+#
+# After applying:
+#   1. Share the `service_account_unique_id` output with Nullify. Nullify
+#      adds it to the federated IAM role's trust-policy allowlist and
+#      returns the role ARN.
+#   2. Deploy the nullify-k8s-collector Helm chart with cloudProvider=gcp
+#      and the values shown in the outputs.
+
+# ---------------------------------------------------------------------------
+# Service account — the OIDC identity the collector pod assumes via
+# Workload Identity. No GCP IAM roles are attached; its only purpose is
+# to sign an ID token that AWS STS will validate.
+# ---------------------------------------------------------------------------
+
+resource "google_service_account" "collector" {
+  project      = var.project_id
+  account_id   = var.service_account_name
+  display_name = "Nullify Kubernetes Collector"
+  description  = "OIDC identity anchor for the Nullify k8s-collector. Bound to the in-cluster Kubernetes ServiceAccount via Workload Identity. Managed by Terraform."
+}
+
+# ---------------------------------------------------------------------------
+# Workload Identity binding — allows the Kubernetes ServiceAccount
+# (running inside the GKE cluster) to impersonate the GCP service account.
+#
+# The `member` format is:
+#   serviceAccount:PROJECT.svc.id.goog[NAMESPACE/KSA_NAME]
+#
+# where NAMESPACE and KSA_NAME must match the Helm chart's
+# serviceAccount.namespace and serviceAccount.name values.
+# ---------------------------------------------------------------------------
+
+resource "google_service_account_iam_member" "workload_identity_binding" {
+  service_account_id = google_service_account.collector.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.k8s_namespace}/${var.k8s_service_account_name}]"
+}

--- a/gcp-integration-setup/terraform/modules/nullify-gke-collector/outputs.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gke-collector/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of the GCP service account. Use this as the iam.gke.io/gcp-service-account annotation in the Helm chart values."
+  value       = google_service_account.collector.email
+}
+
+output "service_account_unique_id" {
+  description = "Unique ID (21-digit number) of the GCP service account. Share this with Nullify so it can be added to the federated AWS IAM role's trust-policy allowlist."
+  value       = google_service_account.collector.unique_id
+}

--- a/gcp-integration-setup/terraform/modules/nullify-gke-collector/variables.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gke-collector/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "GCP project ID where the GKE cluster runs and where the collector service account will be created."
+  type        = string
+}
+
+variable "service_account_name" {
+  description = "Name of the GCP service account to create. The default matches the Helm chart's expectations."
+  type        = string
+  default     = "nullify-k8s-collector"
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.service_account_name))
+    error_message = "service_account_name must be 6-30 characters, start with a letter, and contain only lowercase letters, digits, and hyphens."
+  }
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace where the Nullify k8s-collector is deployed. Must match serviceAccount.namespace in the Helm chart values."
+  type        = string
+  default     = "nullify"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes ServiceAccount name used by the collector pods. Must match serviceAccount.name in the Helm chart values."
+  type        = string
+  default     = "nullify-k8s-collector-sa"
+}

--- a/gcp-integration-setup/terraform/modules/nullify-gke-collector/versions.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gke-collector/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/helm-charts/nullify-k8s-collector/Chart.yaml
+++ b/helm-charts/nullify-k8s-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nullify-k8s-collector
 description: A Helm chart for Nullify's Kubernetes information collector for cloud security scanning
 type: application
-version: 0.1.2
+version: 0.2.0
 maintainers:
   - name: Nullify
     url: https://nullify.ai

--- a/helm-charts/nullify-k8s-collector/README.md
+++ b/helm-charts/nullify-k8s-collector/README.md
@@ -7,27 +7,44 @@ This Helm chart deploys a Kubernetes collector for the Nullify platform to gathe
 - Kubernetes 1.16+
 - Helm 3.0+
 
+## Supported platforms
+
+The same chart runs on **EKS** and **GKE**. Select the platform via `cloudProvider`:
+
+| `cloudProvider` | Cluster  | How the collector authenticates to AWS              |
+| --------------- | -------- | --------------------------------------------------- |
+| `aws` (default) | EKS      | IRSA — ServiceAccount → AWS IAM role                |
+| `gcp`           | GKE      | Workload Identity → `sts:AssumeRoleWithWebIdentity` |
+
+In both cases the collector uploads cluster metadata to the same Nullify-managed
+S3 bucket. No long-lived AWS credential is stored in the customer cluster.
+
 ## Configuration
 
 The following table lists the configurable parameters of the chart and their default values.
 
-> **Required values**: `collector.clusterName`, `collector.s3.bucket`, `collector.kms.keyArn`, and `serviceAccount.annotations.eks.amazonaws.com/role-arn` must be configured before deployment. Get these from the Nullify configure page.
+> **Required values**: `collector.clusterName`, `collector.s3.bucket`, `collector.kms.keyArn`.
+> Platform-specific required values are listed below. Get these from the Nullify configure page.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `cloudProvider` | Platform the collector runs on: `aws` (EKS) or `gcp` (GKE) | `aws` |
 | `serviceAccount.create` | If true, create a new service account | `true` |
-| `serviceAccount.annotations` | Annotations for the service account (IAM role ARN from Nullify configure page) | `eks.amazonaws.com/role-arn: YOUR-NULLIFY-READ-ONLY-ROLE-ARN` |
+| `serviceAccount.annotations` | Annotations for the service account. The chart renders only the annotation that matches `cloudProvider`. | See [values.yaml](./values.yaml) |
 | `serviceAccount.name` | Name of the service account | `nullify-k8s-collector-sa` |
 | `collector.image.repository` | Image repository | `public.ecr.aws/w4o2j2x4/integrations` |
 | `collector.image.tag` | Image tag | `k8s-collector-latest` |
 | `collector.image.pullPolicy` | Pull policy | `Always` |
 | `collector.schedule` | CronJob schedule | `0 0 * * *` (daily at midnight) |
-| `collector.s3.bucket` | S3 bucket for storing data (from Nullify configure page) | `nullify-death-star-dast-k8s` |
+| `collector.s3.bucket` | S3 bucket for storing data (from Nullify configure page) | `YOUR-NULLIFY-S3-BUCKET` |
 | `collector.s3.keyPrefix` | S3 key prefix | `k8s-collector` |
-| `collector.aws.region` | AWS region | `ap-southeast-2` |
-| `collector.clusterName` | Cluster name (must match your actual EKS cluster name) | `YOUR-CLUSTER-NAME` |
+| `collector.aws.region` | AWS region | `us-east-1` |
+| `collector.clusterName` | Cluster name (must match your actual cluster name) | `YOUR-CLUSTER-NAME` |
 | `collector.kms.keyArn` | KMS key ARN for encryption (from Nullify configure page) | `""` |
 | `collector.debug.enabled` | Enable debug logging for troubleshooting | `false` |
+| `collector.gke.nullifyAwsRoleArn` | **GKE only.** Nullify-owned federated AWS IAM role ARN. | `""` |
+| `collector.gke.audience` | **GKE only.** Token audience AWS STS checks against the OIDC provider. Do not change unless Nullify asks you to. | `sts.amazonaws.com` |
+| `collector.gke.webIdentityTokenPath` | **GKE only.** In-pod path of the projected Workload Identity token. | `/var/run/secrets/tokens/gcp-sa-token` |
 | `labels` | Additional labels for the collector resources | `null` |
 
 ## Security Context
@@ -79,9 +96,86 @@ serviceAccount:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/NullifyCollectorRole"
 ```
 
+### GKE with Workload Identity Federation
+
+For GKE clusters, the collector authenticates to AWS without any long-lived credential.
+The flow is:
+
+1. GKE projects a Google-signed ServiceAccount token into the collector pod.
+2. The collector forwards that token to AWS STS `AssumeRoleWithWebIdentity`.
+3. AWS validates the token against the Google OIDC provider and returns short-lived
+   credentials for a Nullify-owned IAM role scoped to your S3 prefix.
+
+#### One-time onboarding
+
+1. **Enable Workload Identity on the cluster** (skip if already enabled):
+
+   ```bash
+   gcloud container clusters update YOUR-CLUSTER \
+     --workload-pool=YOUR-PROJECT.svc.id.goog
+   ```
+
+2. **Create a GCP service account** dedicated to the collector. It does not need any
+   GCP IAM roles — its only job is to sign an OIDC token AWS STS will trust.
+
+   ```bash
+   gcloud iam service-accounts create nullify-k8s-collector \
+     --display-name "Nullify Kubernetes Collector"
+   ```
+
+3. **Send its unique ID to Nullify.** The `uniqueId` is a 21-digit number, not the
+   email. Nullify adds it to the federated IAM role's trust-policy allowlist and
+   gives you back the role ARN.
+
+   ```bash
+   gcloud iam service-accounts describe \
+     nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com \
+     --format='value(uniqueId)'
+   ```
+
+4. **Bind the in-cluster Kubernetes ServiceAccount to the GCP SA** via Workload
+   Identity. The Kubernetes SA name/namespace below must match `serviceAccount.name`
+   and `serviceAccount.namespace` in your Helm values.
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding \
+     nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com \
+     --role roles/iam.workloadIdentityUser \
+     --member "serviceAccount:YOUR-PROJECT.svc.id.goog[nullify/nullify-k8s-collector-sa]"
+   ```
+
+#### Helm values
+
+```yaml
+cloudProvider: gcp
+
+collector:
+  clusterName: "my-gke-cluster"
+  aws:
+    region: "us-east-1"   # AWS region of the Nullify S3 bucket
+  s3:
+    bucket: "your-nullify-bucket"
+  kms:
+    keyArn: "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
+  gke:
+    # Provided by Nullify after step 3 of onboarding.
+    nullifyAwsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: "nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com"
+```
+
+Then install:
+
+```bash
+helm install nullify-k8s-collector ./nullify-k8s-collector -f values-gke.yaml
+```
+
 ### Other Kubernetes Clusters
 
-For non-EKS clusters, you'll need to provide AWS credentials through other means:
+For clusters outside EKS and GKE, you'll need to provide AWS credentials through
+other means:
 
 - Using AWS environment variables in the pod
 - Using instance profiles for nodes running on EC2

--- a/helm-charts/nullify-k8s-collector/templates/NOTES.txt
+++ b/helm-charts/nullify-k8s-collector/templates/NOTES.txt
@@ -7,7 +7,7 @@ about your cluster resources to help identify security vulnerabilities.
 This collector gathers information about your Kubernetes cluster and stores it in an S3 bucket.
 The data collected includes (but is not limited to):
 - Cluster metadata
-- Namespaces 
+- Namespaces
 - Workloads (Pods, Deployments, StatefulSets, DaemonSets, etc.)
 - Service configuration
 - Network policies
@@ -15,6 +15,7 @@ The data collected includes (but is not limited to):
 - PersistentVolumes and PersistentVolumeClaims
 
 ## Configuration
+- Cloud Provider: {{ .Values.cloudProvider | default "aws" }}
 - S3 Bucket: {{ .Values.collector.s3.bucket }}
 - S3 Key Prefix: {{ .Values.collector.s3.keyPrefix }}
 - AWS Region: {{ .Values.collector.aws.region }}
@@ -30,15 +31,30 @@ The data collected includes (but is not limited to):
 - Collection Mode: Full resource data
 {{- end }}
 
+{{- if eq (.Values.cloudProvider | default "aws") "gcp" }}
+
+## Authentication (GKE Workload Identity → AWS STS)
+- GCP Service Account: {{ index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account" | default "NOT SET — required for GKE" }}
+- Nullify AWS Role: {{ .Values.collector.gke.nullifyAwsRoleArn | default "NOT SET — ask Nullify for the role ARN" }}
+- Token Audience: {{ .Values.collector.gke.audience }}
+
+The collector exchanges the projected Google-signed ServiceAccount token for short-lived
+AWS credentials via sts:AssumeRoleWithWebIdentity. No long-lived AWS credential is
+stored in the cluster.
+{{- else }}
+
+## Authentication (EKS IRSA)
 {{- if (index .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn") }}
 - IAM Role: {{ index .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" }}
 {{- else }}
-NOTE: No IAM role was specified for the ServiceAccount. Make sure the collector 
+NOTE: No IAM role was specified for the ServiceAccount. Make sure the collector
 has necessary AWS credentials through other means (instance profile, environment variables, etc.)
+{{- end }}
 {{- end }}
 
 ## Required AWS Permissions
-The IAM role or credentials used by the collector need these permissions(Will already be installed as a part of Nullify's IAM Resources):
+The IAM role or credentials used by the collector need these permissions (already granted
+when Nullify's IAM resources are installed):
 - s3:PutObject
 - s3:GetObject
 - s3:ListBucket
@@ -54,4 +70,4 @@ To check logs from the most recent job run:
   kubectl -n {{ .Values.serviceAccount.namespace }} logs job/$(kubectl -n {{ .Values.serviceAccount.namespace }} get jobs --sort-by=.metadata.creationTimestamp -l app.kubernetes.io/name={{ include "k8s-collector.name" . }} -o jsonpath="{.items[-1].metadata.name}")
 
 To run the job manually:
-  kubectl -n {{ .Values.serviceAccount.namespace }} create job --from=cronjob/{{ include "k8s-collector.name" . }} {{ include "k8s-collector.name" . }}-manual-$(date +%s) 
+  kubectl -n {{ .Values.serviceAccount.namespace }} create job --from=cronjob/{{ include "k8s-collector.name" . }} {{ include "k8s-collector.name" . }}-manual-$(date +%s)

--- a/helm-charts/nullify-k8s-collector/templates/cronjob.yaml
+++ b/helm-charts/nullify-k8s-collector/templates/cronjob.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.collector.enabled -}}
+{{- $isGKE := eq (.Values.cloudProvider | default "aws") "gcp" -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -36,6 +37,15 @@ spec:
               value: "{{ .Values.collector.aws.region }}"
             - name: CLUSTER_NAME
               value: "{{ .Values.collector.clusterName }}"
+            {{- if $isGKE }}
+            # GKE → AWS federation via sts:AssumeRoleWithWebIdentity.
+            # The collector reads AWS_WEB_IDENTITY_TOKEN_FILE, forwards the
+            # Google-signed SA token to AWS STS, and assumes NULLIFY_AWS_ROLE_ARN.
+            - name: NULLIFY_AWS_ROLE_ARN
+              value: "{{ .Values.collector.gke.nullifyAwsRoleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "{{ .Values.collector.gke.webIdentityTokenPath }}"
+            {{- end }}
             {{- if and .Values.collector.dataCollection .Values.collector.dataCollection.excludeNamespaces }}
             - name: EXCLUDE_NAMESPACES
               value: "{{ .Values.collector.dataCollection.excludeNamespaces }}"
@@ -58,5 +68,24 @@ spec:
             {{- end }}
             resources:
               {{- toYaml .Values.collector.resources | nindent 14 }}
+            {{- if $isGKE }}
+            volumeMounts:
+            - name: gcp-sa-token
+              mountPath: {{ dir .Values.collector.gke.webIdentityTokenPath }}
+              readOnly: true
+            {{- end }}
+          {{- if $isGKE }}
+          volumes:
+          - name: gcp-sa-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  # Audience AWS STS validates against the OIDC provider's
+                  # client_id_list. Must be sts.amazonaws.com or AssumeRole
+                  # is rejected.
+                  audience: {{ .Values.collector.gke.audience }}
+                  expirationSeconds: 3600
+                  path: {{ base .Values.collector.gke.webIdentityTokenPath }}
+          {{- end }}
           restartPolicy: OnFailure
-{{- end }} 
+{{- end }}

--- a/helm-charts/nullify-k8s-collector/templates/serviceaccount.yaml
+++ b/helm-charts/nullify-k8s-collector/templates/serviceaccount.yaml
@@ -1,4 +1,19 @@
 {{- if .Values.serviceAccount.create -}}
+{{- $provider := .Values.cloudProvider | default "aws" -}}
+{{- $annotations := dict -}}
+{{- range $k, $v := .Values.serviceAccount.annotations -}}
+  {{- if eq $k "eks.amazonaws.com/role-arn" -}}
+    {{- if eq $provider "aws" -}}
+      {{- $_ := set $annotations $k $v -}}
+    {{- end -}}
+  {{- else if eq $k "iam.gke.io/gcp-service-account" -}}
+    {{- if eq $provider "gcp" -}}
+      {{- $_ := set $annotations $k $v -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $_ := set $annotations $k $v -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,8 +21,8 @@ metadata:
   namespace: {{ .Values.serviceAccount.namespace }}
   labels:
     {{- include "k8s-collector.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }} 
+{{- end }}

--- a/helm-charts/nullify-k8s-collector/values-example.yaml
+++ b/helm-charts/nullify-k8s-collector/values-example.yaml
@@ -2,11 +2,18 @@
 # Copy this file to values-production.yaml and fill in your actual values
 # DO NOT commit values-production.yaml to version control
 #
+# The file below shows the EKS (IRSA) setup. See the bottom of this file
+# for the equivalent GKE (Workload Identity) setup.
+#
 # REQUIRED VALUES (get these from Nullify configure page):
-#   - collector.clusterName: Your exact EKS cluster name
+#   - collector.clusterName: Your exact cluster name
 #   - collector.s3.bucket: S3 bucket name
 #   - collector.kms.keyArn: KMS key ARN
-#   - serviceAccount.annotations.eks.amazonaws.com/role-arn: IAM role ARN
+#   - EKS only: serviceAccount.annotations."eks.amazonaws.com/role-arn"
+#   - GKE only: collector.gke.nullifyAwsRoleArn
+#               serviceAccount.annotations."iam.gke.io/gcp-service-account"
+
+cloudProvider: aws
 
 collector:
   # AWS region (extract from your KMS key ARN)
@@ -66,3 +73,31 @@ tolerations:
 # Additional labels (optional)
 labels:
   environment: "production"
+
+# ---------------------------------------------------------------------------
+# GKE (Workload Identity) example
+# ---------------------------------------------------------------------------
+# Replace the section above with the block below for a GKE deployment.
+# See README.md for one-time onboarding steps (creating the GCP service
+# account, sharing its uniqueId with Nullify, and binding it to the
+# in-cluster ServiceAccount via Workload Identity).
+#
+# cloudProvider: gcp
+#
+# collector:
+#   aws:
+#     region: "us-east-1"          # AWS region of the Nullify S3 bucket
+#   clusterName: "my-gke-cluster"
+#   s3:
+#     bucket: "your-nullify-bucket"
+#     keyPrefix: "k8s-collector"
+#   kms:
+#     keyArn: "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
+#   gke:
+#     # Provided by Nullify after you share the GCP service-account uniqueId.
+#     nullifyAwsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
+#
+# serviceAccount:
+#   annotations:
+#     iam.gke.io/gcp-service-account: "nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com"
+

--- a/helm-charts/nullify-k8s-collector/values.yaml
+++ b/helm-charts/nullify-k8s-collector/values.yaml
@@ -2,10 +2,25 @@
 # This is a YAML-formatted file.
 #
 # REQUIRED VALUES (must be configured before deployment):
-#   - collector.clusterName: Your exact EKS cluster name
+#   - collector.clusterName: Your exact cluster name
 #   - collector.s3.bucket: S3 bucket from Nullify configure page
 #   - collector.kms.keyArn: KMS key ARN from Nullify configure page
-#   - serviceAccount.annotations.eks.amazonaws.com/role-arn: IAM role ARN from Nullify configure page
+#
+# Provider-specific required values:
+#   - EKS: serviceAccount.annotations."eks.amazonaws.com/role-arn"
+#          (IAM role ARN from Nullify configure page)
+#   - GKE: collector.gke.nullifyAwsRoleArn
+#          (Nullify-owned federated AWS IAM role ARN, provided by Nullify
+#           after you share your GCP service-account unique ID)
+#          serviceAccount.annotations."iam.gke.io/gcp-service-account"
+#          (Your GCP service account email, bound to the in-cluster
+#           ServiceAccount via Workload Identity)
+
+# Which cluster platform the collector is running on.
+# Supported values: "aws" (EKS, default) | "gcp" (GKE).
+# - "aws" authenticates via IRSA (service account → AWS IAM role).
+# - "gcp" authenticates via GKE Workload Identity → sts:AssumeRoleWithWebIdentity.
+cloudProvider: aws
 
 # Cluster-level permissions
 clusterRole:
@@ -18,20 +33,20 @@ clusterRoleBinding:
 # Main collector configuration
 collector:
     enabled: true
-    
+
     # AWS region (extract from your KMS key ARN)
     aws:
         region: us-east-1
-    
-    # Must match your actual EKS cluster name exactly
+
+    # Must match your actual cluster name exactly
     clusterName: "YOUR-CLUSTER-NAME"
-    
+
     # Container image
     image:
         repository: public.ecr.aws/w4o2j2x4/integrations
         tag: k8s-collector-latest
         pullPolicy: Always
-    
+
     # Resource limits
     resources:
         limits:
@@ -40,23 +55,23 @@ collector:
         requests:
             cpu: 100m
             memory: 128Mi
-    
+
     # S3 configuration (from Nullify configure page)
     s3:
         bucket: "YOUR-NULLIFY-S3-BUCKET"
         keyPrefix: k8s-collector
-    
+
     # KMS configuration (from Nullify configure page)
     kms:
         keyArn: "arn:aws:kms:REGION:ACCOUNT:key/KEY-ID"
-    
+
     # Debug logging
     debug:
         enabled: false
-    
+
     # CronJob schedule (daily at midnight UTC)
     schedule: "0 0 * * *"
-    
+
     # Security context
     securityContext:
         allowPrivilegeEscalation: false
@@ -65,12 +80,30 @@ collector:
                 - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
-    
+
     # Data collection filters (optional)
     dataCollection:
         # excludeNamespaces: "kube-system,kube-public"
         # includeResources: "pods,services,deployments"
         # metadataOnly: true
+
+    # GKE-specific settings (only used when cloudProvider is "gcp").
+    gke:
+        # Nullify-owned federated AWS IAM role the collector assumes via
+        # sts:AssumeRoleWithWebIdentity. Supplied by Nullify after you share
+        # your GCP service-account unique ID during onboarding.
+        nullifyAwsRoleArn: ""
+
+        # Audience the projected GCP service-account token is minted with.
+        # AWS STS requires this to match the OIDC provider's client_id_list;
+        # "sts.amazonaws.com" is correct for all Nullify deployments and
+        # should not normally be changed.
+        audience: sts.amazonaws.com
+
+        # Path inside the pod where the Workload-Identity-projected token
+        # is mounted. The collector reads this file and forwards the token
+        # to AWS STS. Must match the `AWS_WEB_IDENTITY_TOKEN_FILE` env var.
+        webIdentityTokenPath: /var/run/secrets/tokens/gcp-sa-token
 
 # Helm chart naming
 fullnameOverride: ""
@@ -88,10 +121,22 @@ namespace:
 # Node selector
 nodeSelector: {}
 
-# Service account for IRSA (from Nullify configure page)
+# Service account annotations.
+#
+# The chart picks the right annotation based on `cloudProvider`:
+#   - aws: expects `eks.amazonaws.com/role-arn` (IRSA)
+#   - gcp: expects `iam.gke.io/gcp-service-account` (Workload Identity)
+#
+# Leave the other provider's annotation unset; the chart renders only the
+# one that applies. Extra annotations are passed through unchanged.
 serviceAccount:
     annotations:
+        # Used when cloudProvider=aws (EKS). IAM role ARN from the Nullify
+        # configure page.
         eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT:role/ROLE-NAME"
+        # Used when cloudProvider=gcp (GKE). Your GCP service account email,
+        # e.g. nullify-k8s-collector@your-project.iam.gserviceaccount.com.
+        # iam.gke.io/gcp-service-account: "YOUR-GCP-SA-EMAIL"
     create: true
     name: nullify-k8s-collector-sa
     namespace: nullify


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

Extends the existing `nullify-k8s-collector` Helm chart so the same collector image deploys to both **EKS** and **GKE** with a single `cloudProvider: aws|gcp` values switch. EKS stays the default — existing deployments upgrade with no values changes.

On GKE the chart wires up **AWS's OIDC-federation story in reverse**: GKE Workload Identity → `accounts.google.com` ID token → `sts:AssumeRoleWithWebIdentity` → short-lived AWS creds → S3. No long-lived AWS credential is ever stored in the customer cluster.

## What's in this PR

**Chart (`helm-charts/nullify-k8s-collector/`)**
- `values.yaml` — new top-level `cloudProvider` key (`aws` default) and a `collector.gke` subsection holding `nullifyAwsRoleArn`, `audience`, `webIdentityTokenPath`.
- `templates/serviceaccount.yaml` — renders only the annotation that matches the selected provider (`eks.amazonaws.com/role-arn` for AWS, `iam.gke.io/gcp-service-account` for GCP). Extra custom annotations pass through unchanged.
- `templates/cronjob.yaml` — adds `AWS_WEB_IDENTITY_TOKEN_FILE` / `NULLIFY_AWS_ROLE_ARN` env vars and a projected service-account-token volume (audience `sts.amazonaws.com`) when running on GKE.
- `templates/NOTES.txt` — post-install notes show the active provider and the right auth summary.
- `README.md` — new **Supported platforms** table and a **GKE with Workload Identity Federation** section with the full onboarding runbook (create GCP SA → share `uniqueId` with Nullify → bind via `workloadIdentityUser` → install chart).
- `values-example.yaml` — commented GKE example at the bottom alongside the existing EKS example.
- `Chart.yaml` — bump `0.1.2` → `0.2.0`.

**Top-level README**
- Minor edits in `What's Included`, `Deployment Options`, `Prerequisites`, and `Component Overview` rows to reflect that the chart now supports both platforms. Everything else is unchanged.

## Backwards compatibility

- `cloudProvider` defaults to `aws`, so the rendered EKS output is byte-for-byte identical to 0.1.2 except for chart-version labels.
- Verified with `helm template` that default (EKS) mode renders **no** GKE fields (`iam.gke.io`, `NULLIFY_AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, projected token volume) — clean isolation.

## Test plan

- [x] `helm lint helm-charts/nullify-k8s-collector/` — passes.
- [x] `helm template test helm-charts/nullify-k8s-collector/` (default EKS mode) — renders the expected CronJob + SA with only the EKS annotation and no WIF wiring.
- [x] `helm template test helm-charts/nullify-k8s-collector/ --set cloudProvider=gcp ...` — SA has only the `iam.gke.io/gcp-service-account` annotation, CronJob has both WIF env vars and the projected token volume with audience `sts.amazonaws.com`.
- [ ] Install against a real GKE cluster and verify `sts:AssumeRoleWithWebIdentity` succeeds and the collector uploads to S3 (blocked on the Nullify-side federated IAM role landing — see the companion backend PR in the monorepo).

## Follow-ups (not in this PR)

- Customer-side GCP Terraform module under `gcp-integration-setup/` that creates the GCP service account, binds it to the in-cluster ServiceAccount via Workload Identity, and outputs the `uniqueId` for the customer to share with Nullify. Today the chart README documents the equivalent `gcloud` commands.