### PR TITLE
docs: fix inaccurate README and IMPLEMENTATION references

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,17 +1,12 @@
-# Nullify AWS Integration - Implementation Guide
+# Nullify Cloud Connector - Implementation Guide
 
-This guide is based on analysis of the real Nullify death-star-dast repository and provides production-ready templates for AWS integration.
+Production-ready templates for integrating Nullify's security platform with AWS and GCP environments.
 
-## Key Findings from Nullify Death-Star-DAST Repository
-
-### Configuration Values (Contact Nullify Support)
-- **Nullify AWS Account ID**: `NULLIFY-ACCOUNT-ID` (provided by Nullify support)
-- **Cross-account Role**: `NULLIFY-ROLE-NAME` (provided by Nullify support)
-- **External IDs**: 
-  - CloudFormation: `YOUR-CLOUDFORMATION-EXTERNAL-ID` (provided by Nullify support)
-  - Terraform: `YOUR-TERRAFORM-EXTERNAL-ID` (provided by Nullify support)
-- **Role Naming Convention**: `AWSIntegration-{CustomerName}-NullifyReadOnlyRole`
-- **S3 Bucket**: `NULLIFY-S3-BUCKET` (provided by Nullify support)
+### Configuration Values (from Nullify Console)
+- **Nullify Role ARN**: Provided in the Nullify configure page
+- **External ID**: Provided in the Nullify configure page
+- **S3 Bucket**: Provided in the Nullify configure page
+- **KMS Key ARN**: Provided in the Nullify configure page
 
 ### Architecture Overview
 
@@ -82,16 +77,16 @@ terraform apply -var="customer_name=mycompany" -var="external_id=your-external-i
 
 ### Option 4: CloudFormation
 
-Deploy using the **exact** Nullify CloudFormation template:
+Deploy using the Nullify CloudFormation template:
 
 ```bash
-cd cloudformation/
-aws cloudformation deploy \
-  --template-file nullify-integration-role.yaml \
+cd aws-integration-setup/cloudformation/
+aws cloudformation create-stack \
   --stack-name nullify-aws-integration \
-  --parameter-overrides \
-    CustomerName=mycompany \
-    ExternalID=your-external-id-from-nullify \
+  --template-body file://nullify-cloudformation-template.json \
+  --parameters \
+    ParameterKey=CustomerName,ParameterValue=mycompany \
+    ParameterKey=ExternalID,ParameterValue=your-external-id-from-nullify \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
@@ -103,17 +98,17 @@ The Helm chart deploys a CronJob-based collector similar to the real k8s-collect
 
 ```bash
 # Add the repository
-helm repo add nullify https://your-github-username.github.io/aws-integration-setup
+helm repo add nullify https://nullify-platform.github.io/nullify-cloud-connector/
+helm repo update
 
-# Install with real configuration
-helm install nullify-aws-integration nullify/nullify-aws-integration \
-  --set aws.roleArn="arn:aws:iam::YOUR-ACCOUNT:role/AWSIntegration-mycompany-NullifyReadOnlyRole" \
-  --set aws.externalId="your-external-id" \
-  --set nullify.apiToken="your-api-token" \
-  --set nullify.organizationId="your-org-id" \
+# Install with a values file (recommended)
+helm install nullify-collector nullify/nullify-k8s-collector \
+  -f values-production.yaml \
   --namespace nullify \
   --create-namespace
 ```
+
+See the [chart README](helm-charts/nullify-k8s-collector/README.md) for all configuration options and per-platform (EKS / GKE) onboarding steps.
 
 ### IRSA Configuration
 

--- a/README.md
+++ b/README.md
@@ -58,26 +58,22 @@ Then paste the `service_account_email` and `workload_identity_provider` outputs 
 
 See [`gcp-integration-setup/terraform/README.md`](gcp-integration-setup/terraform/README.md) for the full guide, the org / folder / project scope options, and the gcloud-only installer.
 
-### **Prerequisites (All Methods)**
+### **Prerequisites**
 
-1. **AWS Account** with appropriate permissions
-2. **Nullify Account** and dashboard access
-3. **Kubernetes cluster** for Helm deployments — **EKS** (IRSA) or **GKE** (Workload Identity). See the [chart README](helm-charts/nullify-k8s-collector/README.md#supported-platforms) for per-platform onboarding steps.
+**All methods:**
+1. **Nullify Account** and dashboard access
+2. Log in to **Configure > Integrations** to obtain provider-specific values
 
-**Obtain Configuration Values from Nullify Configure Page:**
+**AWS integration:**
+- AWS account with IAM permissions
+- Values from the Nullify console: Role ARN, External ID, S3 Bucket, KMS Key ARN
+- (Optional) EKS cluster for Kubernetes collector — see [chart README](helm-charts/nullify-k8s-collector/README.md)
 
-1. **Log in to your Nullify configure page**
-2. **Navigate to Configure > Integrations**
-3. **Select AWS integration** to begin setup
-4. **Note the provided values:**
-   - **Nullify Role ARN**: The ARN of Nullify's cross-account role
-   - **External ID**: Unique identifier for secure cross-account access
-   - **S3 Bucket Name**: For secure data transfer
-   - **KMS Key ARN**: For encryption operations
-
-> 📖 **Reference**: For detailed setup instructions, see the [Nullify AWS Integration Documentation](https://docs.nullify.ai/integrations/aws/configuration).
-
-**Alternative**: Contact Nullify Support for assistance with configuration values.
+**GCP integration:**
+- GCP project with `gcloud` authenticated
+- Org or folder admin access (for WIF pool + IAM bindings)
+- Values from the Nullify console: OIDC issuer URI, Tenant ID
+- (Optional) GKE cluster with Workload Identity enabled for Kubernetes collector
 
 ---
 
@@ -262,7 +258,7 @@ nullify-cloud-connector/
 │
 ├── 🤖 .github/workflows/                 # CI/CD Automation
 │   ├── helm-release.yml                  # Auto-publish Helm charts to GitHub Pages
-│   ├── pr-validation.yml                 # PR validation and testing
+│   ├── terraform-validate.yml            # Terraform validation on PRs
 │   └── auto-tag.yml                      # Auto-tag releases on version changes
 │
 ├── ⚙️ helm-charts/                       # 🎯 KUBERNETES DEPLOYMENT
@@ -279,43 +275,35 @@ nullify-cloud-connector/
 │           ├── cronjob.yaml              # Main collector CronJob
 │           └── pre-install-job.yaml      # Pre-installation validation
 │
-└── aws-integration-setup/               # 🏗️ AWS INFRASTRUCTURE
-    │
-    ├── 🏗️ cloudformation/               # CloudFormation Templates
-    │   ├── nullify-cloudformation-template.json  # Main CF template
-    │   └── README.md                     # CloudFormation deployment guide
-    │
+├── aws-integration-setup/               # 🏗️ AWS INFRASTRUCTURE
+│   ├── 🏗️ cloudformation/               # CloudFormation Templates
+│   │   ├── nullify-cloudformation-template.json  # Main CF template
+│   │   └── README.md                     # CloudFormation deployment guide
+│   ├── 🔧 terraform/                     # Terraform Modules
+│   │   ├── modules/                      # Reusable Terraform modules
+│   │   │   ├── nullify-aws-integration/  # AWS IAM resources only
+│   │   │   └── k8s-resources/            # Kubernetes resources only
+│   │   ├── examples/                     # Example configurations
+│   │   ├── terraform.tfvars.example      # Example configuration
+│   │   └── README.md                     # Terraform documentation
+│   └── 🔧 scripts/                       # Utility Scripts
+│       ├── validate-deployment.sh        # Deployment validation
+│       ├── update-helm-repo.sh           # Update Helm repository
+│       ├── cleanup.sh                    # Clean removal script
+│       └── setup-aws-integration.sh      # AWS setup automation
+│
+└── gcp-integration-setup/               # ☁️ GCP INFRASTRUCTURE
     ├── 🔧 terraform/                     # Terraform Modules
-    │   ├── modules/                      # Reusable Terraform modules
-    │   │   ├── nullify-aws-integration/  # AWS IAM resources only
-    │   │   │   ├── main.tf               # Core infrastructure resources
-    │   │   │   ├── variables.tf          # Input variables
-    │   │   │   ├── data.tf               # Data sources and policies
-    │   │   │   ├── locals.tf             # Local values
-    │   │   │   └── outputs.tf            # Output values
-    │   │   └── k8s-resources/            # Kubernetes resources only
-    │   │       ├── main.tf               # Kubernetes resources
-    │   │       ├── variables.tf          # Input variables
-    │   │       └── outputs.tf            # Output values
-    │   ├── examples/                     # Example Terraform configurations
-    │   │   ├── basic/                    # AWS-only integration
-    │   │   └── multi-cluster-complete/   # Multi-cluster EKS integration
-    │   ├── main.tf                       # Root module instantiation
-    │   ├── variables.tf                  # Root input variables
-    │   ├── outputs.tf                    # Root outputs
+    │   ├── modules/
+    │   │   ├── nullify-gcp-integration/  # WIF pool, provider, SA, IAM bindings
+    │   │   └── nullify-gke-collector/    # GKE k8s-collector deployment
+    │   ├── examples/                     # Example configurations
     │   ├── terraform.tfvars.example      # Example configuration
-    │   └── README.md                     # Terraform documentation
-    │
-    ├── 📚 docs/                          # Additional Documentation
-    │   ├── README.md                     # Documentation index
-    │   ├── security-guidelines.md        # Security best practices
-    │   └── troubleshooting.md            # Common issues and solutions
-    │
+    │   └── README.md                     # GCP Terraform documentation
+    ├── 📚 docs/                          # GCP-specific documentation
+    │   └── permissions.md                # Required GCP permissions
     └── 🔧 scripts/                       # Utility Scripts
-        ├── validate-deployment.sh        # Deployment validation
-        ├── update-helm-repo.sh           # Update Helm repository
-        ├── cleanup.sh                    # Clean removal script
-        └── setup-aws-integration.sh      # AWS setup automation
+        └── uninstall.sh                  # Clean removal script
 ```
 
 ### **Component Overview**
@@ -439,11 +427,12 @@ kubectl create job --from=cronjob/nullify-k8s-collector manual-collection -n nul
 
 | Document | Description |
 |----------|-------------|
-| [📖 IMPLEMENTATION.md](IMPLEMENTATION.md) | Implementation details and technical overview |
-| [📖 Chart README](helm-charts/nullify-k8s-collector/README.md) | Chart-specific documentation |
-| [🏗️ CloudFormation README](aws-integration-setup/cloudformation/README.md) | CloudFormation template documentation |
-| [🔧 Terraform README](aws-integration-setup/terraform/README.md) | Terraform modules documentation |
-| [📚 Docs](aws-integration-setup/docs/README.md) | Additional documentation |
+| [IMPLEMENTATION.md](IMPLEMENTATION.md) | Implementation details and technical overview |
+| [Chart README](helm-charts/nullify-k8s-collector/README.md) | Helm chart documentation (EKS + GKE) |
+| [CloudFormation README](aws-integration-setup/cloudformation/README.md) | CloudFormation template documentation |
+| [AWS Terraform README](aws-integration-setup/terraform/README.md) | AWS Terraform modules documentation |
+| [GCP Terraform README](gcp-integration-setup/terraform/README.md) | GCP Terraform modules documentation |
+| [GCP Permissions](gcp-integration-setup/docs/permissions.md) | Required GCP permissions reference |
 
 ## 🐛 **Troubleshooting**
 


### PR DESCRIPTION
## Summary

- Fix Helm chart name, repo URL, and `--set` flags in IMPLEMENTATION.md to match actual chart schema
- Fix CloudFormation template filename (`.yaml` -> `.json`)
- Add GCP directory tree to repo structure diagram (was AWS-only)
- Fix workflow filename reference (`pr-validation.yml` -> `terraform-validate.yml`)
- Remove broken links to nonexistent docs files
- Add GCP prerequisites alongside AWS in the prerequisites section
- Add GCP Terraform and permissions docs to the documentation table

## Test plan

- [ ] Verify all links in README resolve correctly
- [ ] Verify Helm install commands work with the documented values

🤖 Generated with [Claude Code](https://claude.com/claude-code)