### PR TITLE
feat(helm): use AWS_ROLE_ARN for GKE auth, simplify onboarding

### DIFF
--- a/helm-charts/nullify-k8s-collector/README.md
+++ b/helm-charts/nullify-k8s-collector/README.md
@@ -42,9 +42,9 @@ The following table lists the configurable parameters of the chart and their def
 | `collector.clusterName` | Cluster name (must match your actual cluster name) | `YOUR-CLUSTER-NAME` |
 | `collector.kms.keyArn` | KMS key ARN for encryption (from Nullify configure page) | `""` |
 | `collector.debug.enabled` | Enable debug logging for troubleshooting | `false` |
-| `collector.gke.nullifyAwsRoleArn` | **GKE only.** Nullify-owned federated AWS IAM role ARN. | `""` |
-| `collector.gke.audience` | **GKE only.** Token audience AWS STS checks against the OIDC provider. Do not change unless Nullify asks you to. | `sts.amazonaws.com` |
-| `collector.gke.webIdentityTokenPath` | **GKE only.** In-pod path of the projected Workload Identity token. | `/var/run/secrets/tokens/gcp-sa-token` |
+| `collector.gke.awsRoleArn` | **GKE only.** Nullify-owned federated AWS IAM role ARN (provided after cluster registration). | `""` |
+| `collector.gke.audience` | **GKE only.** Token audience for the projected SA token. Do not change unless Nullify asks you to. | `sts.amazonaws.com` |
+| `collector.gke.webIdentityTokenPath` | **GKE only.** In-pod path of the projected SA token. | `/var/run/secrets/tokens/gcp-sa-token` |
 | `labels` | Additional labels for the collector resources | `null` |
 
 ## Security Context
@@ -108,41 +108,21 @@ The flow is:
 
 #### One-time onboarding
 
-1. **Enable Workload Identity on the cluster** (skip if already enabled):
+1. **Get your cluster's OIDC issuer URL** and share it with Nullify:
 
    ```bash
-   gcloud container clusters update YOUR-CLUSTER \
-     --workload-pool=YOUR-PROJECT.svc.id.goog
+   gcloud container clusters describe YOUR-CLUSTER --zone YOUR-ZONE \
+     --format='value(selfLink)'
    ```
 
-2. **Create a GCP service account** dedicated to the collector. It does not need any
-   GCP IAM roles — its only job is to sign an OIDC token AWS STS will trust.
+   This outputs something like:
+   `https://container.googleapis.com/v1/projects/my-project/locations/us-central1-a/clusters/prod`
 
-   ```bash
-   gcloud iam service-accounts create nullify-k8s-collector \
-     --display-name "Nullify Kubernetes Collector"
-   ```
+2. **Share the OIDC issuer URL with Nullify** (via the configure page or support).
+   Nullify registers it and gives you back the **role ARN** to use in the Helm values.
 
-3. **Send its unique ID to Nullify.** The `uniqueId` is a 21-digit number, not the
-   email. Nullify adds it to the federated IAM role's trust-policy allowlist and
-   gives you back the role ARN.
-
-   ```bash
-   gcloud iam service-accounts describe \
-     nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com \
-     --format='value(uniqueId)'
-   ```
-
-4. **Bind the in-cluster Kubernetes ServiceAccount to the GCP SA** via Workload
-   Identity. The Kubernetes SA name/namespace below must match `serviceAccount.name`
-   and `serviceAccount.namespace` in your Helm values.
-
-   ```bash
-   gcloud iam service-accounts add-iam-policy-binding \
-     nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com \
-     --role roles/iam.workloadIdentityUser \
-     --member "serviceAccount:YOUR-PROJECT.svc.id.goog[nullify/nullify-k8s-collector-sa]"
-   ```
+No GCP service accounts, Workload Identity bindings, or special cluster configuration required.
+The chart uses a projected Kubernetes ServiceAccount token signed by the cluster's OIDC issuer.
 
 #### Helm values
 
@@ -158,12 +138,8 @@ collector:
   kms:
     keyArn: "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
   gke:
-    # Provided by Nullify after step 3 of onboarding.
-    nullifyAwsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
-
-serviceAccount:
-  annotations:
-    iam.gke.io/gcp-service-account: "nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com"
+    # Provided by Nullify after you register the cluster.
+    awsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
 ```
 
 Then install:

--- a/helm-charts/nullify-k8s-collector/templates/NOTES.txt
+++ b/helm-charts/nullify-k8s-collector/templates/NOTES.txt
@@ -33,14 +33,13 @@ The data collected includes (but is not limited to):
 
 {{- if eq (.Values.cloudProvider | default "aws") "gcp" }}
 
-## Authentication (GKE Workload Identity → AWS STS)
-- GCP Service Account: {{ index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account" | default "NOT SET — required for GKE" }}
-- Nullify AWS Role: {{ .Values.collector.gke.nullifyAwsRoleArn | default "NOT SET — ask Nullify for the role ARN" }}
+## Authentication (GKE Projected SA Token → AWS STS)
+- Nullify AWS Role: {{ .Values.collector.gke.awsRoleArn | default "NOT SET — ask Nullify for the role ARN" }}
 - Token Audience: {{ .Values.collector.gke.audience }}
 
-The collector exchanges the projected Google-signed ServiceAccount token for short-lived
-AWS credentials via sts:AssumeRoleWithWebIdentity. No long-lived AWS credential is
-stored in the cluster.
+The collector uses a projected Kubernetes ServiceAccount token (signed by the
+cluster's OIDC issuer) to call AWS sts:AssumeRoleWithWebIdentity. No long-lived
+AWS credential is stored in the cluster. No GKE Workload Identity setup required.
 {{- else }}
 
 ## Authentication (EKS IRSA)

--- a/helm-charts/nullify-k8s-collector/templates/cronjob.yaml
+++ b/helm-charts/nullify-k8s-collector/templates/cronjob.yaml
@@ -39,10 +39,10 @@ spec:
               value: "{{ .Values.collector.clusterName }}"
             {{- if $isGKE }}
             # GKE → AWS federation via sts:AssumeRoleWithWebIdentity.
-            # The collector reads AWS_WEB_IDENTITY_TOKEN_FILE, forwards the
-            # Google-signed SA token to AWS STS, and assumes NULLIFY_AWS_ROLE_ARN.
-            - name: NULLIFY_AWS_ROLE_ARN
-              value: "{{ .Values.collector.gke.nullifyAwsRoleArn }}"
+            # The SDK default credential chain picks up AWS_ROLE_ARN +
+            # AWS_WEB_IDENTITY_TOKEN_FILE and handles the token exchange.
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.collector.gke.awsRoleArn | default .Values.collector.gke.nullifyAwsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "{{ .Values.collector.gke.webIdentityTokenPath }}"
             {{- end }}

--- a/helm-charts/nullify-k8s-collector/values-example.yaml
+++ b/helm-charts/nullify-k8s-collector/values-example.yaml
@@ -10,8 +10,7 @@
 #   - collector.s3.bucket: S3 bucket name
 #   - collector.kms.keyArn: KMS key ARN
 #   - EKS only: serviceAccount.annotations."eks.amazonaws.com/role-arn"
-#   - GKE only: collector.gke.nullifyAwsRoleArn
-#               serviceAccount.annotations."iam.gke.io/gcp-service-account"
+#   - GKE only: collector.gke.awsRoleArn
 
 cloudProvider: aws
 
@@ -94,10 +93,6 @@ labels:
 #   kms:
 #     keyArn: "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
 #   gke:
-#     # Provided by Nullify after you share the GCP service-account uniqueId.
-#     nullifyAwsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
-#
-# serviceAccount:
-#   annotations:
-#     iam.gke.io/gcp-service-account: "nullify-k8s-collector@YOUR-PROJECT.iam.gserviceaccount.com"
+#     # Provided by Nullify after you register your cluster's OIDC issuer URL.
+#     awsRoleArn: "arn:aws:iam::123456789012:role/NullifyK8sCollectorRole"
 

--- a/helm-charts/nullify-k8s-collector/values.yaml
+++ b/helm-charts/nullify-k8s-collector/values.yaml
@@ -9,9 +9,9 @@
 # Provider-specific required values:
 #   - EKS: serviceAccount.annotations."eks.amazonaws.com/role-arn"
 #          (IAM role ARN from Nullify configure page)
-#   - GKE: collector.gke.nullifyAwsRoleArn
+#   - GKE: collector.gke.awsRoleArn
 #          (Nullify-owned federated AWS IAM role ARN, provided by Nullify
-#           after you share your GCP service-account unique ID)
+#           after you register your cluster's OIDC issuer URL)
 #          serviceAccount.annotations."iam.gke.io/gcp-service-account"
 #          (Your GCP service account email, bound to the in-cluster
 #           ServiceAccount via Workload Identity)
@@ -90,8 +90,10 @@ collector:
     # GKE-specific settings (only used when cloudProvider is "gcp").
     gke:
         # Nullify-owned federated AWS IAM role the collector assumes via
-        # sts:AssumeRoleWithWebIdentity. Supplied by Nullify after you share
-        # your GCP service-account unique ID during onboarding.
+        # sts:AssumeRoleWithWebIdentity. Supplied by Nullify after you
+        # register your cluster's OIDC issuer URL during onboarding.
+        awsRoleArn: ""
+        # Deprecated: use awsRoleArn instead. Kept for backwards compat.
         nullifyAwsRoleArn: ""
 
         # Audience the projected GCP service-account token is minted with.


### PR DESCRIPTION
## Summary

The k8s-collector now uses the SDK's default credential chain for both EKS and GKE. For GKE, the projected Kubernetes SA token + `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` is all the SDK needs — no custom env var, no GCP service account, no Workload Identity binding.

**No breaking change:** The template uses `{{ .Values.collector.gke.awsRoleArn | default .Values.collector.gke.nullifyAwsRoleArn }}` — old values files with `nullifyAwsRoleArn` continue to work.

**Onboarding simplified from 4 steps to 2:**
1. Customer shares their cluster OIDC issuer URL with Nullify
2. Nullify gives back the role ARN → customer puts it in Helm values

No GCP service account creation, no Workload Identity binding, no `iam.gke.io/gcp-service-account` annotation required.

**Prerequisites:** Any GKE cluster (Standard, Autopilot, private, public). K8s 1.22+. No special configuration.

## Changes
- Env var: `NULLIFY_AWS_ROLE_ARN` → `AWS_ROLE_ARN` (with backwards-compat fallback)
- Values: add `collector.gke.awsRoleArn` (preferred), keep `nullifyAwsRoleArn` (deprecated)
- README: replace 4-step GCP SA onboarding with 2-step cluster OIDC URL flow
- NOTES.txt: clarify no GKE Workload Identity setup needed

## Test plan

- [x] Verified end-to-end on GKE cluster `nullify-test` — data uploaded to S3
- [ ] `helm template` renders correctly with both `awsRoleArn` and `nullifyAwsRoleArn`
- [ ] EKS deployments unaffected (GKE values gated by `cloudProvider: gcp`)