### PR TITLE
feat(gcp): warn on project-scope installs missing organization_id

### DIFF
--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
@@ -57,6 +57,32 @@ resource "terraform_data" "input_validation" {
   }
 }
 
+# ---------------------------------------------------------------------------
+# Soft warning for project-scoped installs without organization_id. The apply
+# still succeeds — single-project is a legitimate POC mode — but the user
+# should know up front that some org-level data won't appear in inventory at
+# this scope. `check` blocks emit warnings without failing the plan.
+# ---------------------------------------------------------------------------
+
+check "single_project_org_data_visibility" {
+  assert {
+    condition     = !(var.scope == "projects" && var.organization_id == "")
+    error_message = <<-EOT
+      Heads up: this install is project-scoped without organization_id, so the
+      Nullify Cloud Connector will not see VPC Service Controls perimeters /
+      access policies or organization policies inherited from the org. Those
+      resources live at organisation scope and the corresponding GCP APIs
+      return empty results when queried at project scope.
+
+      Compute, GKE, Cloud Run, IAM bindings, Cloud SQL, and the rest of the
+      project-scoped inventory are unaffected. To include VPC SC and
+      org-policy data, set organization_id (the long-tail custom role then
+      gets created at the organisation) and re-apply, or switch to
+      scope = "organization" / "folder".
+    EOT
+  }
+}
+
 locals {
   # Predefined viewer roles granted to the Nullify service account. Each role
   # is named here so an auditor can trace why each binding exists.


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

- Follow-up to #47. When a customer installs the GCP cloud connector with `scope = \"projects\"` and no `organization_id`, the apply succeeds and they get a green console verify, but VPC Service Controls perimeters / access policies and organization policies silently never appear in their Nullify inventory — those resources live at the organisation level and the corresponding GCP APIs return empty results when queried at project scope.
- Adds a Terraform `check` block in `modules/nullify-gcp-integration/main.tf` that emits a warning in this exact configuration explaining what's not visible and how to enable it (set `organization_id`, or switch to `scope = \"organization\"` / `\"folder\"`).
- `check` blocks (Terraform 1.5+, already required by the module) emit warnings **without failing the plan**, so legitimate single-project POC installs are unaffected — they just get a heads-up in the plan output.

## Why a `check` block, not a `precondition`

The existing `terraform_data.input_validation` uses preconditions, which **fail** the plan. That's correct for the cases it covers (e.g. `scope = \"folder\"` without `folder_id` cannot work). But here the install genuinely works — single-project is a documented POC mode (`examples/single-project/`) — we just want the user to know about the gap. A precondition would force every single-project user to either set `organization_id` or pass a `--var` override, which is the wrong UX.

## Test plan

- [x] `terraform validate` passes for `examples/single-project`, `examples/folder`, and `examples/organization` against the modified module
- [x] `terraform fmt -check -recursive` clean
- [ ] CI (`terraform-validate.yml`) green across the matrix
- [ ] Manual: re-run plan against the single-project install we hit in #47 and confirm the warning surfaces in the plan output (no creds needed in CI for this — assertion only references vars, so it evaluates pre-refresh)

## Notes

- Org-scoped and folder-scoped installs are unaffected (the `check` condition is only false when `scope == \"projects\" && organization_id == \"\"`).
- No new variables. No breaking changes. Bumps no behavior — only adds a diagnostic.