### PR TITLE
feat(gcp): add image metadata and GKE workload read permissions

### DIFF
--- a/gcp-integration-setup/docs/permissions.md
+++ b/gcp-integration-setup/docs/permissions.md
@@ -52,6 +52,12 @@ Strict allowlist of `*.get` / `*.list` only.
 | `file.instances.get/list` | Filestore instance config. |
 | `redis.instances.get/list` + `memcache.instances.get/list` | Memorystore instance config. |
 | `artifactregistry.repositories.get/list` | Artifact Registry repo metadata (no image content). |
+| `artifactregistry.dockerimages.get/list` + `artifactregistry.tags.get/list` + `artifactregistry.versions.get/list` | Image digest, tag, and version metadata for correlating repository artifacts with deployed images. Layer bytes (`downloadArtifacts`) are intentionally excluded. |
+| `container.deployments.get/list` + `container.statefulSets.get/list` + `container.daemonSets.get/list` + `container.jobs.get/list` + `container.cronJobs.get/list` + `container.pods.get/list` | GKE workload discovery (controllers + pods) via the GKE control-plane proxy. |
+| `container.services.get/list` + `container.ingresses.get/list` + `container.networkPolicies.get/list` | GKE network topology: cluster-IP/LoadBalancer services, ingress rules, NetworkPolicy posture. |
+| `container.serviceAccounts.get/list` + `container.roles.get/list` + `container.roleBindings.get/list` + `container.clusterRoles.get/list` + `container.clusterRoleBindings.get/list` | GKE RBAC — workload→ServiceAccount→role mapping for privilege-escalation analysis. |
+| `container.configMaps.get/list` | ConfigMap discovery. **ConfigMap values are read.** Kubernetes Secret values (`container.secrets.*`) are not requested. |
+| `container.namespaces.get/list` + `container.nodes.get/list` | Namespace and node enumeration. |
 | `dns.managedZones.get/list` + `dns.resourceRecordSets.list` | Cloud DNS zone + record discovery. |
 | `apigateway.gateways.get/list` + `apigateway.apis.get/list` + `apigateway.apiconfigs.get/list` | API Gateway topology. |
 

--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
@@ -143,6 +143,55 @@ locals {
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
 
+    # Artifact Registry image metadata: digests, tags, version history.
+    # Layer bytes (downloadArtifacts) are intentionally not included.
+    "artifactregistry.dockerimages.get",
+    "artifactregistry.dockerimages.list",
+    "artifactregistry.tags.get",
+    "artifactregistry.tags.list",
+    "artifactregistry.versions.get",
+    "artifactregistry.versions.list",
+
+    # GKE workload metadata — read via the GKE control-plane proxy, no in-
+    # cluster collector required. Strict allowlist of get/list verbs only.
+    # Kubernetes Secret values (container.secrets.*) are intentionally NOT
+    # included; ConfigMap values are included and called out separately in
+    # docs/permissions.md.
+    "container.deployments.get",
+    "container.deployments.list",
+    "container.statefulSets.get",
+    "container.statefulSets.list",
+    "container.daemonSets.get",
+    "container.daemonSets.list",
+    "container.jobs.get",
+    "container.jobs.list",
+    "container.cronJobs.get",
+    "container.cronJobs.list",
+    "container.pods.get",
+    "container.pods.list",
+    "container.services.get",
+    "container.services.list",
+    "container.ingresses.get",
+    "container.ingresses.list",
+    "container.networkPolicies.get",
+    "container.networkPolicies.list",
+    "container.serviceAccounts.get",
+    "container.serviceAccounts.list",
+    "container.roles.get",
+    "container.roles.list",
+    "container.roleBindings.get",
+    "container.roleBindings.list",
+    "container.clusterRoles.get",
+    "container.clusterRoles.list",
+    "container.clusterRoleBindings.get",
+    "container.clusterRoleBindings.list",
+    "container.configMaps.get",
+    "container.configMaps.list",
+    "container.namespaces.get",
+    "container.namespaces.list",
+    "container.nodes.get",
+    "container.nodes.list",
+
     # Cloud DNS managed zones + record sets.
     "dns.managedZones.get",
     "dns.managedZones.list",


### PR DESCRIPTION
## Summary

Extends the read-only custom role with two additive capabilities:

1. **Artifact Registry image metadata** — `dockerimages.{get,list}`, `tags.{get,list}`, `versions.{get,list}` so deployed images can be correlated back to their tag
2. **GKE workload read** via the control-plane proxy — Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, Pods, Services, Ingresses, NetworkPolicies, ServiceAccounts, Roles/RoleBindings, ClusterRoles/ClusterRoleBindings, ConfigMaps, Namespaces, Nodes (all `get`/`list` only).

`docs/permissions.md` is updated with a per-permission justification and the explicit exclusions for security review.

## Excluded by design

| Excluded permission | Reason |
| --- | --- |
| `artifactregistry.repositories.downloadArtifacts` | Image layer bytes (data plane). |
| `container.secrets.*` | Kubernetes Secret values. |
| `container.events.*` | Runtime event stream — noisy, may contain sensitive payloads. |
| `container.bindings.*`, `container.tokenReviews.*`, `container.subjectAccessReviews.*` | Write / data-plane verbs. |
| `container.persistentVolumes.*`, `container.persistentVolumeClaims.*` | Volume-mount analysis can be added in a follow-up if needed. |
| `container.customResourceDefinitions.*`, `container.thirdPartyObjects.*` | CRD instance reads (e.g. Istio VirtualService, ArgoCD Application) can be added in a follow-up if needed. |

The role still honours the "strict allowlist of `*.get` / `*.list` only — no mutations and no data-plane reads" discipline stated in the existing code comments.

## Stacking

This PR is stacked on top of `fix/gcp-custom-role-project-scope` because the `custom_role_permissions_common` local that this PR extends is introduced by that fix. Once that lands, retarget the base branch to `main` and rebase.

## Test plan

- [ ] `terraform validate` passes for `gcp-integration-setup/terraform`
- [ ] `terraform plan` in `examples/single-project` shows only the additive permissions as a diff against `fix/gcp-custom-role-project-scope`
- [ ] `terraform plan` in `examples/organization` shows the same additive permissions (these new perms are valid at both project and org custom-role scope)
- [ ] Spot-check: a `gcloud iam roles describe` of the rendered custom role lists the new permissions and does not list `container.secrets.*` or `artifactregistry.repositories.downloadArtifacts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)