### PR TITLE
feat(gcp): grant table + topic getIamPolicy permissions

### DIFF
--- a/gcp-integration-setup/docs/permissions.md
+++ b/gcp-integration-setup/docs/permissions.md
@@ -56,7 +56,8 @@ Strict allowlist of `*.get` / `*.list` only.
 | `apigateway.gateways.get/list` + `apigateway.apis.get/list` + `apigateway.apiconfigs.get/list` | API Gateway topology. |
 | `storage.buckets.get/list` + `storage.buckets.getIamPolicy` | Cloud Storage bucket settings + bucket-level IAM. No `storage.objects.*`. |
 | `secretmanager.secrets.get/list` | Secret Manager: secret name, labels, replication policy, rotation config. No `secretmanager.versions.access` (payloads). |
-| `bigquery.datasets.get/list` + `bigquery.tables.get/list` + `bigquery.routines.get/list` | BigQuery dataset/table/routine schema + IAM. No `bigquery.tables.getData` (rows) and no `bigquery.jobs.create` (no query execution / billing). |
+| `bigquery.datasets.get/list` + `bigquery.tables.get/list` + `bigquery.tables.getIamPolicy` + `bigquery.routines.get/list` | BigQuery dataset/table/routine schema + IAM. `bigquery.tables.getIamPolicy` is granted explicitly (separate from `bigquery.dataViewer`, which we **do not** grant because it would also expose row data). No `bigquery.tables.getData` (rows) and no `bigquery.jobs.create` (no query execution / billing). |
+| `pubsub.topics.getIamPolicy` | Pub/Sub topic-level IAM (detects topics bound to `allUsers` / `allAuthenticatedUsers`). The predefined `roles/pubsub.viewer` already grants metadata listing; this adds only the IAM-policy surface. No `pubsub.topics.publish` or `subscriptions.consume`. |
 | `cloudbuild.buildTriggers.get/list` | Cloud Build trigger config (repo binding, file filter, substitutions). No build logs or artifacts. |
 | `batch.jobs.get/list` | Cloud Batch job spec. No task logs or output artifacts. |
 | `workflows.workflows.get/list` | Cloud Workflows: workflow definitions only. **Not** `workflows.executions.*` or `workflows.stepEntries.*` — execution arguments and step inputs/outputs are runtime data. |

--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
@@ -173,10 +173,14 @@ locals {
 
     # BigQuery dataset/table/routine schema + IAM. No bigquery.tables.getData
     # (row data) and no bigquery.jobs.create (no query execution / billing).
+    # tables.getIamPolicy is broken out separately from tables.get because
+    # roles/bigquery.dataViewer would also grant row reads — we want only
+    # the IAM-policy surface, never table data.
     "bigquery.datasets.get",
     "bigquery.datasets.list",
     "bigquery.tables.get",
     "bigquery.tables.list",
+    "bigquery.tables.getIamPolicy",
     "bigquery.routines.get",
     "bigquery.routines.list",
 
@@ -215,6 +219,12 @@ locals {
     # Org-scope only — at project scope these calls return empty harmlessly.
     "securitycenter.sources.get",
     "securitycenter.sources.list",
+
+    # Pub/Sub topic-level IAM. The predefined roles/pubsub.viewer role
+    # already grants topic/subscription metadata listing; this adds the
+    # IAM-policy surface so CSPM can detect topics bound to allUsers /
+    # allAuthenticatedUsers. No pubsub.topics.publish or subscriptions.consume.
+    "pubsub.topics.getIamPolicy",
   ]
 
   # Permissions only includable in an org-scoped custom role. GCP rejects


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

Adds two resource-level IAM read permissions to the GCP connector custom role to unblock new CSPM rules landing in nullify-platform PR #4777.

| Permission | Why it's needed | What we deliberately do NOT grant |
|---|---|---|
| `bigquery.tables.getIamPolicy` | Detect tables bound to `allUsers` / `allAuthenticatedUsers` and other table-level IAM misconfigurations. | `roles/bigquery.dataViewer` (would also expose row data) — we want only the IAM surface. |
| `pubsub.topics.getIamPolicy` | Detect topics bound to public principals. | `pubsub.topics.publish` and `subscriptions.consume` — read-only IAM only. |

Both grants are pure-read and consistent with the connector's metadata-only posture documented in `main.tf`.

## Files

- `gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf` — adds 2 entries to `custom_role_permissions_common` with inline explanatory comments
- `gcp-integration-setup/docs/permissions.md` — updates the customer-facing permission table to reflect the additions and the explicit rationale for not using `roles/bigquery.dataViewer`

## Test plan

- [x] `terraform fmt -recursive` (no changes)
- [x] `terraform validate` — success
- [ ] Apply on a dev tenant connector and confirm the custom role rev bumps to include the new permissions: `gcloud iam roles describe nullifyCloudConnector --project=<dev-project>`
- [ ] Confirm nullify-platform PR #4777 scans succeed against the same dev tenant and produce the new `gcp-bigquery-table-public` and `gcp-pubsub-no-public-access` findings when seeded misconfigurations exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)