### PR TITLE
feat(gcp): add opt-in Firestore API enablement

### DIFF
--- a/gcp-integration-setup/terraform/main.tf
+++ b/gcp-integration-setup/terraform/main.tf
@@ -12,4 +12,5 @@ module "nullify_gcp_integration" {
   wif_pool_id             = var.wif_pool_id
   wif_provider_id         = var.wif_provider_id
   service_account_name    = var.service_account_name
+  enable_firestore_api    = var.enable_firestore_api
 }

--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/apis.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/apis.tf
@@ -21,3 +21,16 @@ resource "google_project_service" "required" {
   service            = each.value
   disable_on_destroy = false
 }
+
+# Optional scan-target API. Firestore / Datastore-mode database discovery
+# (datastore.databases.list/getMetadata) requires the Firestore API to be
+# enabled on the project. Gated behind a flag and off by default so the
+# connector never turns on an API for a service the customer may not use —
+# the datastore.* read permissions are granted regardless. Set
+# enable_firestore_api = true to opt in.
+resource "google_project_service" "firestore" {
+  count              = var.enable_firestore_api ? 1 : 0
+  project            = var.host_project_id
+  service            = "firestore.googleapis.com"
+  disable_on_destroy = false
+}

--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/variables.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/variables.tf
@@ -85,3 +85,9 @@ variable "service_account_name" {
   type        = string
   default     = "nullify-cloud-connector"
 }
+
+variable "enable_firestore_api" {
+  description = "When true, enable firestore.googleapis.com on the host project so Nullify can discover Firestore / Datastore-mode databases. Off by default to keep the enabled-API surface minimal; the datastore.* read permissions are granted regardless of this flag."
+  type        = bool
+  default     = false
+}

--- a/gcp-integration-setup/terraform/variables.tf
+++ b/gcp-integration-setup/terraform/variables.tf
@@ -75,3 +75,9 @@ variable "service_account_name" {
   type        = string
   default     = "nullify-cloud-connector"
 }
+
+variable "enable_firestore_api" {
+  description = "When true, enable firestore.googleapis.com so Nullify can discover Firestore / Datastore-mode databases. Off by default; datastore.* read permissions are granted regardless."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds an `enable_firestore_api` flag (default `false`) that enables `firestore.googleapis.com` on the host project, required for Firestore / Datastore-mode database discovery. Off by default to keep the enabled-API surface minimal; the `datastore.*` read permissions are unchanged.