### PR TITLE
feat(gcp): support organization-wide deployment

### DIFF
--- a/gcp-integration-setup/terraform/README.md
+++ b/gcp-integration-setup/terraform/README.md
@@ -22,6 +22,10 @@ secrets.
 - IAM bindings granting the Nullify service account a curated set of
   predefined viewer roles plus the custom role above. Bound at organisation
   scope by default; folder and per-project scopes are also supported.
+- **`roles/browser` (read-only hierarchy browse)** — granted only when
+  `scope = "organization"` or `scope = "folder"`. This lets Nullify
+  enumerate the projects under your chosen scope. It grants no access to
+  resource data (no objects, secrets, rows, or any other payload).
 - The required Google Cloud APIs on the host project
   (`iam`, `iamcredentials`, `sts`, `cloudresourcemanager`, `cloudasset`,
   `serviceusage`).
@@ -33,6 +37,18 @@ secrets.
   Nullify can list BigQuery datasets but cannot read table rows.
 - No write permissions. Nullify cannot modify your environment.
 - No long-lived secrets. Revoke at any time with `terraform destroy`.
+
+## Deployment modes
+
+| Mode | `scope` value | What to set | Coverage |
+|---|---|---|---|
+| **Organisation-wide** _(recommended)_ | `"organization"` | `organization_id` | Every project in the organisation, including projects created after `terraform apply`. No need to re-run Terraform when projects are added. |
+| **Folder** | `"folder"` | `organization_id` + `folder_id` | Every project under the specified folder, including projects added to that folder later. |
+| **Specific projects** | `"projects"` | `project_ids` (list) | Only the projects you list explicitly. New projects are **not** covered automatically — update `project_ids` and re-run `terraform apply` to add them. |
+
+For most organisations, the **organisation-wide mode is the easiest to
+operate**: deploy once and Nullify automatically covers current and future
+projects without any further Terraform changes.
 
 ## Prerequisites
 

--- a/gcp-integration-setup/terraform/examples/organization/main.tf
+++ b/gcp-integration-setup/terraform/examples/organization/main.tf
@@ -1,4 +1,9 @@
-# Example: organisation-wide install (recommended).
+# Example: organisation-wide install (recommended, one-shot deployment).
+#
+# Set scope = "organization" to cover every project in the organisation with a
+# single terraform apply. Nullify automatically discovers current projects and
+# any projects created later — no need to update this configuration or re-run
+# Terraform when new projects are added to the organisation.
 
 module "nullify" {
   source = "../../"

--- a/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
+++ b/gcp-integration-setup/terraform/modules/nullify-gcp-integration/main.tf
@@ -227,6 +227,12 @@ locals {
     "pubsub.topics.getIamPolicy",
   ]
 
+  # Read-only hierarchy-browse role granted only for org/folder installs so
+  # Nullify can enumerate the projects under the chosen scope (auto-enrollment
+  # of current + future projects). Not granted for scope = "projects" — there
+  # the customer enumerates projects explicitly, so discovery is unnecessary.
+  discovery_roles = ["roles/browser"]
+
   # Permissions only includable in an org-scoped custom role. GCP rejects
   # these in a project-scoped custom role with "Permission ... is not valid"
   # because the underlying resources (VPC SC access policies / perimeters,
@@ -372,6 +378,16 @@ resource "google_organization_iam_member" "custom" {
   member = "serviceAccount:${google_service_account.nullify_cloud_connector.email}"
 }
 
+# Project-discovery binding — organisation scope. Lets Nullify enumerate every
+# project under the org so org-wide installs auto-cover current + future
+# projects. roles/browser is hierarchy-browse only (no resource data).
+resource "google_organization_iam_member" "discovery" {
+  for_each = var.scope == "organization" ? toset(local.discovery_roles) : toset([])
+  org_id   = var.organization_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.nullify_cloud_connector.email}"
+}
+
 # ---------------------------------------------------------------------------
 # Role bindings — folder scope.
 #
@@ -394,6 +410,14 @@ resource "google_folder_iam_member" "custom" {
   folder = var.folder_id
   role   = local.custom_role_id
   member = "serviceAccount:${google_service_account.nullify_cloud_connector.email}"
+}
+
+# Project-discovery binding — folder scope.
+resource "google_folder_iam_member" "discovery" {
+  for_each = var.scope == "folder" ? toset(local.discovery_roles) : toset([])
+  folder   = var.folder_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.nullify_cloud_connector.email}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds support for **organization-wide deployment** of the Nullify GCP integration, alongside the existing per-project setup. With `scope = "organization"` (or `"folder"`), Nullify can enumerate and cover every project under the organization/folder — including projects created later — from a single Terraform apply, with no per-project onboarding.

## What changed

- **`roles/browser` binding** (read-only) granted to the Nullify service account, **only** for `scope = "organization"` and `scope = "folder"`. This lets Nullify enumerate the projects under the chosen scope so org-wide installs auto-cover current and future projects. It grants no resource-data access (hierarchy browse only) and is **not** granted for `scope = "projects"`.
- **Docs** — the Terraform README gains a "Deployment modes" section explaining the organization-wide one-shot model (current + future projects covered automatically) vs. specifying explicit projects; the `examples/organization` example is annotated accordingly.

## Backward compatibility

Existing per-project installs are unaffected — no new bindings or behavior for `scope = "projects"`, and no new variables.

## Testing

`terraform fmt -check -recursive` and `terraform validate` pass (Google provider v6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Nullify-Platform/codesmith/nullify-cloud-connector/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784878166&installation_id=90420261&pr_number=54&repository=Nullify-Platform%2Fnullify-cloud-connector&return_to=https%3A%2F%2Fgithub.com%2FNullify-Platform%2Fnullify-cloud-connector%2Fpull%2F54&signature=2fb6154a5cdd1d1049907c0e1e6ddfeb412dd4d2d63157ce3f30557a2cbb10ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->