### PR TITLE
feat: add Azure cloud connector WIF integration module

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,16 +1,17 @@
 name: Terraform validate
 
 # Lints and validates the customer-facing Terraform modules so a regression
-# in either gcp-integration-setup or aws-integration-setup gets caught in CI
-# rather than at customer apply time. The historical incident this is meant
-# to prevent: a project-scoped custom role bound at the org level (#40) that
-# only blew up when a customer ran terraform apply.
+# in gcp-integration-setup, aws-integration-setup, or azure-integration-setup
+# gets caught in CI rather than at customer apply time. The historical incident
+# this is meant to prevent: a project-scoped custom role bound at the org level
+# (#40) that only blew up when a customer ran terraform apply.
 
 on:
   pull_request:
     paths:
       - "gcp-integration-setup/**"
       - "aws-integration-setup/**"
+      - "azure-integration-setup/**"
       - ".github/workflows/terraform-validate.yml"
   push:
     branches:
@@ -18,6 +19,7 @@ on:
     paths:
       - "gcp-integration-setup/**"
       - "aws-integration-setup/**"
+      - "azure-integration-setup/**"
       - ".github/workflows/terraform-validate.yml"
 
 permissions:
@@ -37,6 +39,9 @@ jobs:
           - aws-integration-setup/terraform
           - aws-integration-setup/terraform/examples/basic
           - aws-integration-setup/terraform/examples/multi-cluster-complete
+          - azure-integration-setup/terraform
+          - azure-integration-setup/terraform/examples/management-group
+          - azure-integration-setup/terraform/examples/subscriptions
     steps:
       - uses: actions/checkout@v4
 

--- a/azure-integration-setup/terraform/README.md
+++ b/azure-integration-setup/terraform/README.md
@@ -1,0 +1,111 @@
+# Nullify Azure Cloud Connector — Terraform
+
+Provisions read-only access to your Azure environment for the Nullify Cloud
+Connector, using Workload Identity Federation (WIF).
+
+## What this provisions
+
+- An **Entra application registration** + **service principal** Nullify
+  authenticates as.
+- A **federated identity credential** on that application, pinned to Nullify's
+  OIDC issuer and to your specific Nullify tenant id (via the credential
+  subject `nullify-tenant:<tenant_id>`).
+- A single **built-in Reader** role assignment, at either a management group
+  (recommended — inherited by every subscription underneath) or on a list of
+  specific subscriptions.
+
+## Optional: Entra directory read
+
+The built-in Reader role covers every ARM-plane resource, **including RBAC role
+assignments**. It grants nothing on the Microsoft Graph plane, so Nullify's
+Entra directory processors (service principals, applications, users, groups,
+credential expiry) and its conditional-access-policy processor read nothing and
+degrade to a no-op.
+
+Set `enable_directory_read = true` to additionally grant the connector two
+admin-consented Microsoft Graph application permissions:
+
+| Permission           | Enables                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| `Directory.Read.All` | Entra service principals, applications, users, groups, credential-expiry |
+| `Policy.Read.All`    | Conditional access policies                                              |
+
+This is **opt-in and default-off**. `Directory.Read.All` is a tenant-wide
+directory read — a materially larger grant than ARM Reader — and consenting to
+it requires a **Global Administrator** (or Privileged Role Administrator). If
+you only want cloud-resource and RBAC coverage, leave it off.
+
+## Authentication mode
+
+This module provisions **workload identity federation (WIF)** — the app carries
+a federated credential trusting Nullify's OIDC issuer, and **no client secret or
+certificate is created**. WIF is the recommended mode: there is no long-lived
+credential to store, rotate, or leak, and access is revoked by deleting the
+federated credential.
+
+Nullify also supports a **service principal** auth mode (a client secret on the
+same app). This module deliberately does **not** provision that secret: a
+Terraform-managed secret would live in Terraform state and `terraform output`,
+reintroducing exactly the secret-handling burden WIF removes. If your
+environment cannot use federation, create a client secret on the application
+yourself (Entra portal → the app → Certificates & secrets, or
+`az ad app credential reset`), then select **Service Principal** mode in the
+Nullify console and paste the secret there. The app, service principal, and
+Reader role this module creates are used unchanged for both modes — only the
+credential type on the app differs.
+
+## Prerequisites
+
+### Installer-side permissions
+
+The operator running `terraform apply` needs, in the target Entra tenant:
+
+- **Application Administrator** (or equivalent) to create the app registration,
+  service principal, and federated credential.
+- **User Access Administrator** or **Owner** on the target management group or
+  subscriptions to create the Reader role assignment.
+
+Authenticate with `az login` before running Terraform; both providers pick up
+the az CLI session.
+
+## Quick start
+
+```sh
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+Paste the `entra_tenant_id` and `application_client_id` outputs into the Nullify
+console under **Settings → Cloud Integrations → Azure**, set the auth mode to
+**Workload Identity Federation**, then click **Verify** and **Save**.
+
+## Required inputs
+
+| Input                     | Description                                                               |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `customer_name`           | Short identifier for your org; appended to the app display name.          |
+| `scope`                   | `management_group` (recommended) or `subscriptions`.                      |
+| `management_group_id`     | Management group ID. Required for `management_group` scope.               |
+| `subscription_ids`        | Subscription GUIDs. Required for `subscriptions` scope.                   |
+| `nullify_oidc_issuer_url` | Nullify OIDC issuer (from the console).                                   |
+| `nullify_tenant_id`       | **Raw** Nullify tenant id — the module adds the `nullify-tenant:` prefix. |
+
+## Revoking access
+
+Run `terraform destroy` from the `terraform/` directory. This removes the
+federated credential, the application/service principal, and the role
+assignment. Access is revoked immediately.
+
+## Troubleshooting
+
+- **Verification fails in the console** — confirm the `federated_credential_subject`
+  output matches the subject Nullify expects (`nullify-tenant:<your tenant id>`).
+  Pasting the prefixed value into `nullify_tenant_id` (double-prefixing) or a
+  wrong tenant id is the most common cause; auth fails silently on a subject
+  mismatch.
+- **`RoleAssignmentExists`** on re-apply — a Reader assignment for this principal
+  already exists at that scope; import it or remove the stale one.

--- a/azure-integration-setup/terraform/examples/management-group/main.tf
+++ b/azure-integration-setup/terraform/examples/management-group/main.tf
@@ -1,0 +1,23 @@
+# Example: management-group install (recommended). Reader is granted once on
+# the management group and Azure inherits it to every subscription underneath.
+
+module "nullify" {
+  source = "../../"
+
+  customer_name = "acme-corp"
+
+  scope               = "management_group"
+  management_group_id = "acme-root-mg"
+
+  # From the Nullify console (Settings -> Cloud Integrations -> Azure).
+  nullify_oidc_issuer_url = "https://gcp.nullify.ai"
+  nullify_tenant_id       = "GitHub-XXXXXXXXX"
+}
+
+output "application_client_id" {
+  value = module.nullify.application_client_id
+}
+
+output "entra_tenant_id" {
+  value = module.nullify.entra_tenant_id
+}

--- a/azure-integration-setup/terraform/examples/subscriptions/main.tf
+++ b/azure-integration-setup/terraform/examples/subscriptions/main.tf
@@ -1,0 +1,23 @@
+# Example: per-subscription install (e.g. a proof of concept on a single
+# subscription). Reader is granted directly on each subscription GUID.
+
+module "nullify" {
+  source = "../../"
+
+  customer_name = "acme-corp"
+
+  scope            = "subscriptions"
+  subscription_ids = ["00000000-0000-0000-0000-000000000000"]
+
+  # From the Nullify console (Settings -> Cloud Integrations -> Azure).
+  nullify_oidc_issuer_url = "https://gcp.nullify.ai"
+  nullify_tenant_id       = "GitHub-XXXXXXXXX"
+}
+
+output "application_client_id" {
+  value = module.nullify.application_client_id
+}
+
+output "entra_tenant_id" {
+  value = module.nullify.entra_tenant_id
+}

--- a/azure-integration-setup/terraform/main.tf
+++ b/azure-integration-setup/terraform/main.tf
@@ -1,0 +1,12 @@
+module "nullify_azure_integration" {
+  source = "./modules/nullify-azure-integration"
+
+  customer_name           = var.customer_name
+  scope                   = var.scope
+  management_group_id     = var.management_group_id
+  subscription_ids        = var.subscription_ids
+  nullify_oidc_issuer_url = var.nullify_oidc_issuer_url
+  nullify_tenant_id       = var.nullify_tenant_id
+  application_name        = var.application_name
+  enable_directory_read   = var.enable_directory_read
+}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/data.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/data.tf
@@ -1,0 +1,4 @@
+# Current Entra directory (tenant) the azuread provider is authenticated
+# against. Used only to surface the tenant id as an output so the customer
+# can paste it into the Nullify console.
+data "azuread_client_config" "current" {}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/graph.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/graph.tf
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------
+# Optional Phase 2: Microsoft Graph directory read.
+#
+# The base module grants only the ARM built-in Reader role, which covers every
+# ARM-plane processor (subscriptions, compute, storage, NSGs, and RBAC role
+# assignments). It grants NOTHING on the Microsoft Graph plane, so the Entra
+# directory processors -- `entradirectory` (service principals, applications,
+# users, groups, credential expiry) and `entraid` (conditional access
+# policies) -- have no token scope and degrade to a no-op.
+#
+# Setting enable_directory_read = true grants the connector's service principal
+# two Graph APPLICATION permissions and admin-consents them, so those
+# processors succeed:
+#   - Directory.Read.All -> users, groups, applications, service principals
+#   - Policy.Read.All     -> conditional access policies
+#
+# This is intentionally opt-in and default-off: Directory.Read.All is a
+# tenant-wide directory read, a materially larger grant than ARM Reader, and
+# it requires a Global Administrator (or Privileged Role Administrator) to
+# consent. Customers who only want cloud-resource + RBAC coverage never take
+# on that grant.
+
+# The first-party Microsoft Graph service principal in this tenant. Its
+# app_role_ids map lets us reference Graph permissions by name instead of
+# hard-coding the well-known GUIDs.
+data "azuread_service_principal" "msgraph" {
+  count     = var.enable_directory_read ? 1 : 0
+  client_id = "00000003-0000-0000-c000-000000000000"
+}
+
+# Directory.Read.All -- read users, groups, applications, service principals.
+# Feeds the `entradirectory` processor.
+resource "azuread_app_role_assignment" "directory_read_all" {
+  count               = var.enable_directory_read ? 1 : 0
+  app_role_id         = data.azuread_service_principal.msgraph[0].app_role_ids["Directory.Read.All"]
+  principal_object_id = azuread_service_principal.nullify_cloud_connector.object_id
+  resource_object_id  = data.azuread_service_principal.msgraph[0].object_id
+}
+
+# Policy.Read.All -- read conditional access policies. Feeds the `entraid`
+# processor.
+resource "azuread_app_role_assignment" "policy_read_all" {
+  count               = var.enable_directory_read ? 1 : 0
+  app_role_id         = data.azuread_service_principal.msgraph[0].app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.nullify_cloud_connector.object_id
+  resource_object_id  = data.azuread_service_principal.msgraph[0].object_id
+}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/main.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/main.tf
@@ -1,0 +1,112 @@
+# Nullify Azure Cloud Connector
+#
+# This module provisions read-only access to an Azure environment for the
+# Nullify Cloud Connector. The trust model is Workload Identity Federation
+# (WIF) with OIDC as the source -- Nullify acts as an OpenID Connect identity
+# provider, minting a per-tenant RS256 JWT whose `sub` claim is
+# `nullify-tenant:<tenant_id>`. Entra exchanges that subject token for a
+# short-lived access token on the application this module creates, then that
+# token is used with the built-in Reader role to enumerate resources.
+#
+# No client secret or certificate is minted by this module. The only trust
+# anchor is the federated identity credential, which is pinned to Nullify's
+# OIDC issuer AND to this customer's specific Nullify tenant id via the
+# subject. Unlike GCP's provider there is no separate attribute-condition
+# layer: Entra matches the token `sub` against the credential `subject`
+# EXACTLY, so the subject IS the per-tenant isolation. A wrong or unprefixed
+# subject is a silent auth failure, never a security downgrade.
+#
+# Access is read-only: the single role granted is the built-in Reader role,
+# which carries no data-plane permissions (no blob contents, no key vault
+# secret values, no database rows). The customer can revoke access at any time
+# by deleting the application, the federated credential, or the role
+# assignment (`terraform destroy` removes all three).
+
+locals {
+  # The federated credential subject Nullify's minted token must carry. The
+  # `nullify-tenant:` prefix is applied HERE, exactly once -- the customer
+  # supplies the raw tenant id. This is the single per-tenant isolation
+  # boundary; getting it wrong fails auth silently.
+  federated_subject = "nullify-tenant:${var.nullify_tenant_id}"
+
+  application_display_name = "${var.application_name}-${var.customer_name}"
+}
+
+# ---------------------------------------------------------------------------
+# Input validation that needs to look at multiple variables. Per-variable
+# `validation` blocks can't reference other vars, so a no-op terraform_data
+# resource with `precondition` checks handles the scope/id pairing.
+# ---------------------------------------------------------------------------
+
+resource "terraform_data" "input_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.scope != "management_group" || var.management_group_id != ""
+      error_message = "scope = \"management_group\" requires management_group_id to be set."
+    }
+    precondition {
+      condition     = var.scope != "subscriptions" || length(var.subscription_ids) > 0
+      error_message = "scope = \"subscriptions\" requires subscription_ids to be non-empty."
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Entra application + service principal Nullify authenticates as. No secret.
+# ---------------------------------------------------------------------------
+
+resource "azuread_application" "nullify_cloud_connector" {
+  display_name = local.application_display_name
+  description  = "Read-only application Nullify authenticates as via Workload Identity Federation. Managed by Terraform."
+}
+
+resource "azuread_service_principal" "nullify_cloud_connector" {
+  client_id   = azuread_application.nullify_cloud_connector.client_id
+  description = "Service principal for the Nullify Cloud Connector application."
+}
+
+# ---------------------------------------------------------------------------
+# Federated identity credential trusting Nullify's OIDC issuer for this
+# tenant's subject only. This is the sole trust anchor -- no long-lived
+# secret exists.
+# ---------------------------------------------------------------------------
+
+resource "azuread_application_federated_identity_credential" "nullify" {
+  application_id = azuread_application.nullify_cloud_connector.id
+  display_name   = "nullify-oidc"
+  description    = "Trusts Nullify's OIDC issuer for federated access scoped to this tenant."
+
+  # Nullify mints a signed RS256 JWT in-process and presents it as the client
+  # assertion. Entra fetches the JWKS from `${issuer}/.well-known/jwks.json`
+  # to verify the signature, then matches the token `sub` against `subject`.
+  issuer    = var.nullify_oidc_issuer_url
+  subject   = local.federated_subject
+  audiences = ["api://AzureADTokenExchange"]
+}
+
+# ---------------------------------------------------------------------------
+# Role assignment -- management-group scope. One Reader binding at the
+# management group; Azure inherits it to every subscription underneath.
+# ---------------------------------------------------------------------------
+
+resource "azurerm_role_assignment" "reader_management_group" {
+  count = var.scope == "management_group" ? 1 : 0
+  scope = "/providers/Microsoft.Management/managementGroups/${var.management_group_id}"
+  # Reference the built-in role by name, not by a hand-built role_definition_id.
+  # azurerm resolves the name to the scope-qualified id and stores it
+  # canonically; a hand-built tenant-relative id drifts against what Azure
+  # returns and forces a needless replace-on-every-apply.
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.nullify_cloud_connector.object_id
+}
+
+# ---------------------------------------------------------------------------
+# Role assignment -- per-subscription scope.
+# ---------------------------------------------------------------------------
+
+resource "azurerm_role_assignment" "reader_subscription" {
+  for_each             = var.scope == "subscriptions" ? toset(var.subscription_ids) : toset([])
+  scope                = "/subscriptions/${each.value}"
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.nullify_cloud_connector.object_id
+}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/main.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/main.tf
@@ -2,24 +2,14 @@
 #
 # This module provisions read-only access to an Azure environment for the
 # Nullify Cloud Connector. The trust model is Workload Identity Federation
-# (WIF) with OIDC as the source -- Nullify acts as an OpenID Connect identity
+# (WIF) with OIDC as the source. Nullify acts as an OpenID Connect identity
 # provider, minting a per-tenant RS256 JWT whose `sub` claim is
 # `nullify-tenant:<tenant_id>`. Entra exchanges that subject token for a
 # short-lived access token on the application this module creates, then that
 # token is used with the built-in Reader role to enumerate resources.
-#
-# No client secret or certificate is minted by this module. The only trust
-# anchor is the federated identity credential, which is pinned to Nullify's
-# OIDC issuer AND to this customer's specific Nullify tenant id via the
-# subject. Unlike GCP's provider there is no separate attribute-condition
-# layer: Entra matches the token `sub` against the credential `subject`
-# EXACTLY, so the subject IS the per-tenant isolation. A wrong or unprefixed
-# subject is a silent auth failure, never a security downgrade.
-#
-# Access is read-only: the single role granted is the built-in Reader role,
-# which carries no data-plane permissions (no blob contents, no key vault
-# secret values, no database rows). The customer can revoke access at any time
-# by deleting the application, the federated credential, or the role
+
+# Access is read-only and can be revoked at any time by deleting
+# the application, the federated credential, or the role
 # assignment (`terraform destroy` removes all three).
 
 locals {

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/outputs.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/outputs.tf
@@ -1,0 +1,29 @@
+output "application_client_id" {
+  description = "Client (application) ID of the Entra app Nullify authenticates as. Paste this into the Nullify console under Settings -> Cloud Integrations -> Azure -> Client ID."
+  value       = azuread_application.nullify_cloud_connector.client_id
+}
+
+output "service_principal_object_id" {
+  description = "Object ID of the service principal. Useful when manually inspecting role assignments via `az role assignment list`."
+  value       = azuread_service_principal.nullify_cloud_connector.object_id
+}
+
+output "federated_credential_subject" {
+  description = "The exact subject Nullify's minted token must carry (`nullify-tenant:<tenant_id>`). Surfaced so the value can be cross-checked against the Nullify console."
+  value       = local.federated_subject
+}
+
+output "entra_tenant_id" {
+  description = "The Entra directory (tenant) ID the application lives in. Paste this into the Nullify console under Settings -> Cloud Integrations -> Azure -> Directory (Tenant) ID."
+  value       = data.azuread_client_config.current.tenant_id
+}
+
+output "scope" {
+  description = "Echoes the scope chosen at apply time so it shows up in the plan output for auditors."
+  value       = var.scope
+}
+
+output "directory_read_enabled" {
+  description = "Whether Phase 2 Microsoft Graph directory read (Directory.Read.All + Policy.Read.All) was granted. When false, the entradirectory and entraid processors degrade to a no-op."
+  value       = var.enable_directory_read
+}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/variables.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/variables.tf
@@ -1,0 +1,64 @@
+variable "customer_name" {
+  description = "Short identifier for your organisation. Used by Nullify support to correlate console support requests with this install. Embedded in the application's display name so it is easy to find in the Entra portal."
+  type        = string
+  validation {
+    condition     = length(var.customer_name) >= 2 && length(var.customer_name) <= 30
+    error_message = "customer_name must be between 2 and 30 characters."
+  }
+}
+
+variable "scope" {
+  description = "Whether Nullify should be granted read access across a whole management group (recommended for full coverage) or only on a list of specific subscriptions."
+  type        = string
+  default     = "management_group"
+  validation {
+    condition     = contains(["management_group", "subscriptions"], var.scope)
+    error_message = "scope must be one of \"management_group\" or \"subscriptions\"."
+  }
+}
+
+variable "management_group_id" {
+  description = "Azure management group ID (the name/ID, not the display name) to grant Reader on. Required when scope = \"management_group\". Nullify then reads every subscription under this management group."
+  type        = string
+  default     = ""
+}
+
+variable "subscription_ids" {
+  description = "List of subscription GUIDs to grant Reader on. Required when scope = \"subscriptions\"."
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = alltrue([for s in var.subscription_ids : can(regex("^[0-9a-fA-F-]{36}$", s))])
+    error_message = "each subscription_ids entry must be a 36-character subscription GUID."
+  }
+}
+
+variable "nullify_oidc_issuer_url" {
+  description = "Nullify's OIDC issuer URL (e.g. https://gcp.nullify.ai for prod, https://gcp.dev.nullify.ai for dev). Provided in the Nullify console under Settings -> Cloud Integrations -> Azure. Azure fetches the JWKS document from `{issuer}/.well-known/jwks.json` to verify the federated subject token signature. The host is `gcp.*` because Nullify runs one shared OIDC signer per environment across all clouds."
+  type        = string
+  validation {
+    condition     = startswith(var.nullify_oidc_issuer_url, "https://") && !endswith(var.nullify_oidc_issuer_url, "/")
+    error_message = "nullify_oidc_issuer_url must start with https:// and not end with a trailing slash."
+  }
+}
+
+variable "nullify_tenant_id" {
+  description = "Your Nullify tenant id (raw, e.g. GitHub-1234567). Provided in the Nullify console under Settings -> Cloud Integrations -> Azure. This module prefixes it with `nullify-tenant:` to form the federated credential subject; paste the RAW value here, not the prefixed form. Azure matches the incoming token's `sub` claim against this subject EXACTLY, so a wrong or unprefixed value is a silent auth failure."
+  type        = string
+  validation {
+    condition     = length(var.nullify_tenant_id) > 0 && length(var.nullify_tenant_id) <= 100 && can(regex("^[A-Za-z0-9_-]+$", var.nullify_tenant_id))
+    error_message = "nullify_tenant_id must be 1-100 characters of [A-Za-z0-9_-]. Paste the raw tenant id; do not include the nullify-tenant: prefix."
+  }
+}
+
+variable "application_name" {
+  description = "Display name for the Entra application registration Nullify authenticates as. The customer_name is appended so multiple installs are distinguishable in the Entra portal."
+  type        = string
+  default     = "nullify-cloud-connector"
+}
+
+variable "enable_directory_read" {
+  description = "Opt-in Phase 2. When true, grants the connector's service principal the Microsoft Graph application permissions Directory.Read.All and Policy.Read.All (admin-consented) so Nullify can enumerate the Entra directory (service principals, applications, users, groups, credential expiry) and conditional access policies. Default false: the base grant is ARM Reader only. Enabling this requires a Global Administrator to consent and is a tenant-wide directory read -- a materially larger grant than Reader."
+  type        = bool
+  default     = false
+}

--- a/azure-integration-setup/terraform/modules/nullify-azure-integration/versions.tf
+++ b/azure-integration-setup/terraform/modules/nullify-azure-integration/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.47.0, < 4.0.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100.0, < 5.0.0"
+    }
+  }
+}

--- a/azure-integration-setup/terraform/outputs.tf
+++ b/azure-integration-setup/terraform/outputs.tf
@@ -1,0 +1,32 @@
+output "application_client_id" {
+  description = "Paste this into the Nullify console under Settings -> Cloud Integrations -> Azure -> Client ID."
+  value       = module.nullify_azure_integration.application_client_id
+}
+
+output "entra_tenant_id" {
+  description = "Paste this into the Nullify console under Settings -> Cloud Integrations -> Azure -> Directory (Tenant) ID."
+  value       = module.nullify_azure_integration.entra_tenant_id
+}
+
+output "federated_credential_subject" {
+  description = "The exact subject Nullify's minted token must carry. Cross-check against the Nullify console if verification fails."
+  value       = module.nullify_azure_integration.federated_credential_subject
+}
+
+output "next_steps" {
+  description = "What to do after a successful terraform apply."
+  value       = <<-EOT
+
+    Nullify Azure integration provisioned successfully.
+
+    Next steps:
+      1. Open the Nullify console -> Settings -> Cloud Integrations -> Azure.
+      2. Paste the entra_tenant_id output above into "Directory (Tenant) ID".
+      3. Paste the application_client_id output above into "Client ID".
+      4. Ensure the auth mode is "Workload Identity Federation".
+      5. Click "Verify", then "Save".
+
+    Access is read-only (built-in Reader role) with no client secret. To revoke
+    at any time, run `terraform destroy` from this directory.
+  EOT
+}

--- a/azure-integration-setup/terraform/providers.tf
+++ b/azure-integration-setup/terraform/providers.tf
@@ -1,5 +1,3 @@
-provider "azuread" {}
-
 provider "azurerm" {
   features {}
 

--- a/azure-integration-setup/terraform/providers.tf
+++ b/azure-integration-setup/terraform/providers.tf
@@ -1,0 +1,7 @@
+provider "azuread" {}
+
+provider "azurerm" {
+  features {}
+
+  resource_provider_registrations = "none"
+}

--- a/azure-integration-setup/terraform/terraform.tfvars.example
+++ b/azure-integration-setup/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars and fill in. Values in the Nullify console under
+# Settings -> Cloud Integrations -> Azure.
+
+customer_name = "acme-corp"
+
+# Recommended: grant Reader across a whole management group.
+scope               = "management_group"
+management_group_id = "acme-root-mg"
+
+# Alternative: grant Reader on specific subscriptions only.
+# scope            = "subscriptions"
+# subscription_ids = ["00000000-0000-0000-0000-000000000000"]
+
+# From the Nullify console. Use https://gcp.dev.nullify.ai for a dev stack.
+nullify_oidc_issuer_url = "https://gcp.nullify.ai"
+
+# RAW Nullify tenant id -- the module adds the nullify-tenant: prefix.
+nullify_tenant_id = "GitHub-XXXXXXXXX"

--- a/azure-integration-setup/terraform/variables.tf
+++ b/azure-integration-setup/terraform/variables.tf
@@ -1,0 +1,56 @@
+variable "customer_name" {
+  description = "Short identifier for your organisation. Used by Nullify support to correlate requests with this install, and appended to the Entra application display name."
+  type        = string
+}
+
+variable "scope" {
+  description = "Granularity of access. \"management_group\" grants Reader on a management group so Nullify reads every subscription underneath (recommended). \"subscriptions\" grants Reader only on the subscription_ids list."
+  type        = string
+  default     = "management_group"
+  validation {
+    condition     = contains(["management_group", "subscriptions"], var.scope)
+    error_message = "scope must be one of \"management_group\" or \"subscriptions\"."
+  }
+}
+
+variable "management_group_id" {
+  description = "Azure management group ID (not display name) to grant Reader on. Required when scope = \"management_group\"."
+  type        = string
+  default     = ""
+}
+
+variable "subscription_ids" {
+  description = "List of subscription GUIDs to grant Reader on. Required when scope = \"subscriptions\"."
+  type        = list(string)
+  default     = []
+}
+
+variable "nullify_oidc_issuer_url" {
+  description = "Nullify's OIDC issuer URL. Provided in the Nullify console under Settings -> Cloud Integrations -> Azure."
+  type        = string
+  validation {
+    condition     = startswith(var.nullify_oidc_issuer_url, "https://") && !endswith(var.nullify_oidc_issuer_url, "/")
+    error_message = "nullify_oidc_issuer_url must start with https:// and not end with a trailing slash."
+  }
+}
+
+variable "nullify_tenant_id" {
+  description = "Your Nullify tenant id, RAW (e.g. GitHub-1234567). Provided in the Nullify console under Settings -> Cloud Integrations -> Azure. The module prefixes it with `nullify-tenant:` to form the federated credential subject -- do NOT include the prefix here."
+  type        = string
+  validation {
+    condition     = length(var.nullify_tenant_id) > 0 && length(var.nullify_tenant_id) <= 100 && can(regex("^[A-Za-z0-9_-]+$", var.nullify_tenant_id))
+    error_message = "nullify_tenant_id must be 1-100 characters of [A-Za-z0-9_-]. Paste the raw tenant id; do not include the nullify-tenant: prefix."
+  }
+}
+
+variable "application_name" {
+  description = "Base display name for the Entra application registration Nullify authenticates as."
+  type        = string
+  default     = "nullify-cloud-connector"
+}
+
+variable "enable_directory_read" {
+  description = "When true, grants the connector Microsoft Graph Directory.Read.All + Policy.Read.All so Nullify can read the Entra directory and conditional access policies. Default false (ARM Reader only)"
+  type        = bool
+  default     = false
+}

--- a/azure-integration-setup/terraform/versions.tf
+++ b/azure-integration-setup/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.47.0, < 4.0.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100.0, < 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds an `azure-integration-setup/` Terraform module that provisions read-only
Azure access for the Nullify Cloud Connector, mirroring the existing
`gcp-integration-setup/` shape.

Access is a single built-in **Reader** role assignment, at either a management
group (inherited by every subscription underneath) or a list of specific
subscriptions.

## Optional Entra directory read

Reader covers every ARM-plane resource (including RBAC role assignments) but
nothing on Microsoft Graph. `enable_directory_read = true` additionally grants
two admin-consented Graph application permissions so Nullify can enumerate the
Entra directory and conditional access policies:

| Permission | Enables |
|---|---|
| `Directory.Read.All` | Entra service principals, applications, users, groups, credential-expiry |
| `Policy.Read.All` | Conditional access policies |

Default off. `Directory.Read.All` is a tenant-wide directory read and requires a
Global Administrator to consent.

## Structure

```
azure-integration-setup/terraform/
├── main.tf, variables.tf, outputs.tf, providers.tf, versions.tf
├── terraform.tfvars.example
├── README.md
├── examples/{management-group,subscriptions}/main.tf
└── modules/nullify-azure-integration/
    ├── main.tf        # app + SP + federated cred + Reader
    ├── graph.tf       # optional Graph directory-read grants
    ├── data.tf, variables.tf, outputs.tf, versions.tf
```

## Auth mode note

The module provisions WIF only. Nullify also supports a service-principal auth
mode (client secret), but the module deliberately does not create that secret —
a Terraform-managed secret would live in state and `terraform output`,
reintroducing the secret-handling burden WIF removes. Customers who require SP
create the secret themselves and paste it into the console; the app + SP +
Reader this module creates are used unchanged for both modes.

## Validation

Validated end-to-end against a live Azure subscription with the context
scanner's local harness:

- WIF token exchange (Nullify dev OIDC signer → Entra → ARM) succeeds; Reader
  honored across two regions.
- RBAC role assignments captured; with `enable_directory_read` the Entra
  directory processors capture service principals / applications / users /
  groups and conditional-access, and credential-expiry classification fires.
- Without the Graph grant, the directory processors degrade to a no-op and the
  Reader floor is unaffected.
- Both WIF and service-principal (manually-created secret) auth modes verified
  against the same app.
